### PR TITLE
Improvements to "manage_tools install" ... command

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -480,11 +480,13 @@ def manage_tools(args=None):
             revision = args[3]
         else:
             revision = None
-        tools.install_tool(gi,toolshed,repo,owner,
-                           revision=revision,
-                           tool_panel_section=options.tool_panel_section)
+        status = tools.install_tool(
+            gi,toolshed,repo,owner,revision=revision,
+            tool_panel_section=options.tool_panel_section)
+        sys.exit(status)
     elif command == 'update':
         if len(args) != 3:
             p.error("Need to supply toolshed, owner and repo")
         toolshed,owner,repo = args[:3]
-        tools.update_tool(gi,toolshed,repo,owner)
+        status = tools.update_tool(gi,toolshed,repo,owner)
+        sys.exit(status)

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -601,7 +601,7 @@ def install_tool(gi,tool_shed,name,owner,
             revision = revision.split(':')[1]
         print "Revision  :\t%s" % revision
     else:
-        print "Revision  : <newest>"
+        print "Revision  :\t<newest>"
     # Get available revisions
     revisions = shed.repositories.get_ordered_installable_revisions(name,
                                                                     owner)
@@ -634,12 +634,13 @@ def install_tool(gi,tool_shed,name,owner,
             if tool_panel_section == section.id or \
                tool_panel_section == section.name:
                 tool_panel_section_id = section.id
-                print "Existing tool panel section: '%s' (%s)" % \
+                print "Existing tool panel section: '%s' (id '%s')" % \
                     (section.name,tool_panel_section_id)
                 break
         if not tool_panel_section_id:
             print "New tool panel section: '%s'" % tool_panel_section
         else:
+            print "No tool panel section specified"
             tool_panel_section = None
     # Get toolshed URL
     tool_shed_url = normalise_toolshed_url(tool_shed)


### PR DESCRIPTION
Various improvements to the `manage_tools install ...` command, including:
- check if requested tool repository/revision is already installed
- handle tool revisions that include the version number
- poll Galaxy until tool is installed or times out
- exit status reflects success or failure of install/update operation
- tidy up screen output
