### PR TITLE
Enable management of API keys from CLI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,11 @@ for a local Galaxy instance::
 
   % nebulizer add localhost http://127.0.0.1:8080 4af252f2250818d14949b3cf0aed476a
 
+Alternatively: if you don't have the API key then nebulizer will fetch it
+if you give it a user name, for example::
+
+  % nebulizer add localhost http://127.0.0.1:8080 --username me@example.org
+
 Each alias is stored in a tab-delimited line with the format
 ``alias|URL|API key``, for example::
 

--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,15 @@ Setup
 
 Although ``nebulizer``'s commands can be used without additional setup, it is
 possible to create shortcuts in the form of 'aliases' to Galaxy URLs and API
-key pairs, by creating a ``.nebulizer`` file in your home directory, e.g.::
+key pairs, which are stored in a ``.nebulizer`` file in your home directory.
 
-  % touch ~/.nebulizer
+This can be managed using the ``nebulizer`` utility, e.g. to add new alias
+for a local Galaxy instance::
 
-and populating with tab-delimited lines with ``alias|URL|API key``, for
-example::
+  % nebulizer add localhost http://127.0.0.1:8080 4af252f2250818d14949b3cf0aed476a
+
+Each alias is stored in a tab-delimited line with the format
+``alias|URL|API key``, for example::
 
   localhost	http://127.0.0.1:8080	4af252f2250818d14949b3cf0aed476a
 
@@ -44,6 +47,9 @@ instead of::
 
   % manage_users list http://127.0.0.1:8080 -k 4af252f2250818d14949b3cf0aed476a
 
+See below for more information on managing the stored aliases and
+associated information.
+
 Commands and usage examples
 ---------------------------
 
@@ -52,6 +58,11 @@ Currently ``nebulizer`` offers three utilities:
  * ``manage_users``: list and create user accounts
  * ``manage_libraries``: list, create and populate data libraries
  * ``manage_tools``: list and install tools from toolsheds
+
+In addition there is a utility for managing stored information on
+Galaxy instances that you wish to interact with::
+
+ * ``nebulizer``: list and manage API keys for Galaxy instances
 
 Some random examples (note that command names etc are subject to change
 without notice while these utilities are under development):
@@ -116,12 +127,32 @@ List all the tool repositories that have available updates or upgrades::
 
 Install the most recent FastQC from the main toolshed::
 
-  manage_tools install --tool-panel-section="NGS: QC and manipulation" \
+  manage_tools install localhost \
+    --tool-panel-section="NGS: QC and manipulation" \
     toolshed.g2.bx.psu.edu devteam fastqc
 
 Update FastQC tool to latest installable revision::
 
-  manage_tools update toolshed.g2.bx.psu.edu devteam fastqc
+  manage_tools update localhost toolshed.g2.bx.psu.edu devteam fastqc
+
+Managing Galaxy instance aliases and information
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+List the stored aliases and associated Galaxy instances::
+
+  nebulizer list
+
+Add a new alias called 'production' for a Galaxy instance::
+
+  nebulizer add production http:://galaxy.org/ 5e7a1264905c8f0beb80002f7de13a40
+
+Update the API key for 'production'::
+
+  nebulizer update production --new-api-key=37b6430624255b8c61a137abd69ae3bb
+
+Remove the entry for 'production'::
+
+  nebulizer remove production
 
 Handling SSL certificate failures
 ---------------------------------

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -24,28 +24,122 @@ class Credentials:
 
     """
 
-    def __init__(self):
-        self._key_file = os.path.join(os.path.expanduser("~"),
-                                           '.nebulizer')
+    def __init__(self,key_file=None):
+        """
+        Create a new Credentials instance
+
+        Arguments:
+          key_file (str): if supplied then should specify
+            the path to the credentials file (defaults to
+            $HOME/.nebulizer)
+
+        """
+        if key_file is None:
+            key_file = os.path.join(os.path.expanduser("~"),
+                                    '.nebulizer')
+        self._key_file = os.path.abspath(key_file)
+
+    def list_keys(self):
+        """
+        List aliases for API keys stored in credentials file
+
+        Returns:
+          List: list of aliases.
+
+        """
+        key_names = []
+        if os.path.exists(self._key_file):
+            with open(self._key_file,'r') as fp:
+                for line in fp:
+                    if line.startswith('#') or not line.strip():
+                        continue
+                    key_names.append(line.strip().split('\t')[0])
+        return key_names
 
     def store_key(self,name,url,api_key):
-        """Store a Galaxy API key
+        """
+        Store a Galaxy API key
 
         Appends an entry to the key file.
 
+        Arguments:
+          name (str): alias to store the key against
+          url (str): URL of the Galaxy instance
+          api_key (str): API key for the Galaxy instance 
+
         """
-        with open(self._key_file,'w+') as fp:
+        with open(self._key_file,'a') as fp:
             fp.write("%s\t%s\t%s\n" % (name,url,api_key))
 
+    def remove_key(self,name):
+        """
+        Remove a Galaxy API key
+
+        Removes a key entry from the key file.
+
+        Arguments:
+          name (str) alias of the key to be removed
+
+        """
+        key_names = self.list_keys()
+        if name not in key_names:
+            logging.error("'%s': not found" % name)
+            return
+        # Store the keys
+        cached_keys = {
+            name: list(self.fetch_key(name))
+            for name in key_names
+        }
+        # Wipe the key file
+        with open(self._key_file,'w') as fp:
+            fp.write("# .nebulizer\n#Aliases\tGalaxy URL\t#API key\n")
+        # Store the cached keys again
+        for alias in key_names:
+            if name != alias:
+                url,api_key = cached_keys[alias]
+                self.store_key(alias,url,api_key)
+
+    def update_key(self,name,new_url=None,new_api_key=None):
+        """
+        Update a Galaxy API key
+
+        Updates the stored information in the key file.
+
+        Arguments:
+          name (str): alias of the key entry to be updated
+          new_url (str): optional, new URL for the Galaxy
+            instance
+          new_api_key (str): optional, new API key for the
+            Galaxy instance
+        
+        """
+        try:
+            url,api_key = self.fetch_key(name)
+        except KeyError:
+            logging.error("'%s': not found" % name)
+            return
+        if new_url:
+            url = new_url
+        if new_api_key:
+            api_key = new_api_key
+        self.remove_key(name)
+        self.store_key(name,url,api_key)
+
     def fetch_key(self,name):
-        """Fetch credentials associated with a Galaxy instance
+        """
+        Fetch credentials associated with a Galaxy instance
 
-        Looks up the credentials associated with the
-        alias 'name', and returns the tuple:
+        Returns the credentials (i.e. Galaxy URL and API key)
+        associated with the specified alias
 
-        (GALAXY_URL,API_KEY)
+        Raises a KeyError if no entry matching the alias is
+        found.
 
-        Raises a KeyError if no matching alias is found.
+        Arguments:
+          name (str): alias of the key entry to fetch
+
+        Returns:
+          Tuple: consisting of (GALAXY_URL,API_KEY)
 
         """
         if os.path.exists(self._key_file):

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -92,7 +92,7 @@ class Credentials:
         }
         # Wipe the key file
         with open(self._key_file,'w') as fp:
-            fp.write("# .nebulizer\n#Aliases\tGalaxy URL\t#API key\n")
+            fp.write("#.nebulizer\n#Aliases\tGalaxy URL\tAPI key\n")
         # Store the cached keys again
         for alias in key_names:
             if name != alias:

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -327,8 +327,8 @@ def get_user_api_key(gi,username=None):
             user = galaxy.users.UserClient(gi).get_current_user()
             print "Username: %s" % username
         except ConnectionError:
-            sys.stderr.write("Cannot determine user associated with "
-                             "this instance\n")
+            logging.error("Cannot determine user associated with "
+                          "this instance\n")
             return
     else:
         # Fetch the details for the specified user
@@ -338,7 +338,7 @@ def get_user_api_key(gi,username=None):
                 user = u
                 break
     if user is None:
-        sys.stderr.write("Cannot get info for user '%s'\n" % username)
+        logging.error("Cannot get info for user '%s'\n" % username)
         return
     # Get the API key
     user_id = user.id

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -311,6 +311,45 @@ def check_new_user_info(gi,email,username):
         return False
     return True
 
+def get_user_api_key(gi,username=None):
+    """
+    Retrieve an API key for a user
+
+    Arguments:
+      username (str): email address or username for the
+        user to get the API key for; default is to get
+        the key for the current user
+
+    """
+    if username is None:
+        # Fetch the details for the current user
+        try:
+            user = galaxy.users.UserClient(gi).get_current_user()
+            print "Username: %s" % username
+        except ConnectionError:
+            sys.stderr.write("Cannot determine user associated with "
+                             "this instance\n")
+            return
+    else:
+        # Fetch the details for the specified user
+        user = None
+        for u in get_users(gi):
+            if (u.email == username) or (u.username == username):
+                user = u
+                break
+    if user is None:
+        sys.stderr.write("Cannot get info for user '%s'\n" % username)
+        return
+    # Get the API key
+    user_id = user.id
+    try:
+        api_key = galaxy.users.UserClient(gi).create_user_apikey(user_id)
+    except galaxy.client.ConnectionError,ex:
+        print "Failed to fetch API key for user '%s': " % username
+        print ex
+        return
+    return api_key
+
 def check_username_format(username):
     """
     Check that format of 'username' is valid

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+import unittest
+import tempfile
+import shutil
+import os
+from nebulizer.core import Credentials
+
+class TestCredentials(unittest.TestCase):
+    """
+    Tests for the 'Credentials' class
+
+    """
+    def setUp(self):
+        # Create temp working dir
+        self.tmpdir = tempfile.mkdtemp(suffix='TestCredentials')
+
+    def tearDown(self):
+        # Remove the temporary test directory
+        shutil.rmtree(self.tmpdir)
+
+    def _make_key_file(self):
+        # Create a key file for testing
+        tmp_key_file = os.path.join(self.tmpdir,'.nebulizer')
+        with open(tmp_key_file,'w') as fp:
+            fp.write("""# .nebulizer
+production\thttp://prod.example.org\t37b6444b8c62a137ab306242
+devel\thttp://devel.example.org\t137ab30624237b6444b8c62a
+local\thttp://127.0.0.1:8080\tb8c62624237b6444137ab30
+""")
+        return tmp_key_file
+
+    def test_list_keys(self):
+        """
+        Credentials.list_keys: lists aliases
+        """
+        tmp_key_file = self._make_key_file()
+        credentials = Credentials(key_file=tmp_key_file)
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'devel',
+                          'local'])
+
+    def test_fetch_key(self):
+        """
+        Credentials.fetch_key: fetches correct data from key file
+        """
+        tmp_key_file = self._make_key_file()
+        credentials = Credentials(key_file=tmp_key_file)
+        self.assertEqual(credentials.fetch_key('production'),
+                         ('http://prod.example.org',
+                          '37b6444b8c62a137ab306242'))
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel.example.org',
+                          '137ab30624237b6444b8c62a'))
+        self.assertEqual(credentials.fetch_key('local'),
+                         ('http://127.0.0.1:8080',
+                          'b8c62624237b6444137ab30'))
+        self.assertRaises(KeyError,credentials.fetch_key,'nonexistent')
+
+    def test_store_key(self):
+        """
+        Credentials.store_key: appends new key to key file
+        """
+        tmp_key_file = self._make_key_file()
+        credentials = Credentials(key_file=tmp_key_file)
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'devel',
+                          'local'])
+        credentials.store_key('beta-staging',
+                              'http://beta-staging.example.org',
+                              '137ab30624237b6444b8c62a')
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'devel',
+                          'local',
+                          'beta-staging'])
+        self.assertEqual(credentials.fetch_key('production'),
+                         ('http://prod.example.org',
+                          '37b6444b8c62a137ab306242'))
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel.example.org',
+                          '137ab30624237b6444b8c62a'))
+        self.assertEqual(credentials.fetch_key('local'),
+                         ('http://127.0.0.1:8080',
+                          'b8c62624237b6444137ab30'))
+        self.assertEqual(credentials.fetch_key('beta-staging'),
+                         ('http://beta-staging.example.org',
+                          '137ab30624237b6444b8c62a'))
+
+    def test_remove_key(self):
+        """
+        Credentials.remove_key: removes key from key file
+        """
+        tmp_key_file = self._make_key_file()
+        credentials = Credentials(key_file=tmp_key_file)
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'devel',
+                          'local'])
+        credentials.remove_key('devel')
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'local'])
+        self.assertEqual(credentials.fetch_key('production'),
+                         ('http://prod.example.org',
+                          '37b6444b8c62a137ab306242'))
+        self.assertEqual(credentials.fetch_key('local'),
+                         ('http://127.0.0.1:8080',
+                          'b8c62624237b6444137ab30'))
+        credentials.remove_key('nonexistent')
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'local'])
+        self.assertEqual(credentials.fetch_key('production'),
+                         ('http://prod.example.org',
+                          '37b6444b8c62a137ab306242'))
+        self.assertEqual(credentials.fetch_key('local'),
+                         ('http://127.0.0.1:8080',
+                          'b8c62624237b6444137ab30'))
+
+    def test_update_key(self):
+        """
+        Credentials.update_key: updates details in key file
+        """
+        tmp_key_file = self._make_key_file()
+        credentials = Credentials(key_file=tmp_key_file)
+        self.assertEqual(credentials.list_keys(),
+                         ['production',
+                          'devel',
+                          'local'])
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel.example.org',
+                          '137ab30624237b6444b8c62a'))
+        credentials.update_key('devel')
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel.example.org',
+                          '137ab30624237b6444b8c62a'))
+        credentials.update_key('devel',
+                               new_url='http://devel2.example.org')
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel2.example.org',
+                          '137ab30624237b6444b8c62a'))
+        credentials.update_key('devel',
+                               new_api_key='eadef00d245c3d0135ba9ccae7e77aef')
+        self.assertEqual(credentials.fetch_key('devel'),
+                         ('http://devel2.example.org',
+                          'eadef00d245c3d0135ba9ccae7e77aef'))
+        credentials.update_key('devel',
+                               new_url='http://devel.example.org',
+                               new_api_key='137ab30624237b6444b8c62a')


### PR DESCRIPTION
This PR implements the `nebulizer` utility with a number of commands that allow the API keys stored in the `~/.nebulizer` file to be managed from the command line. Specifically:
- `list`: shows the stored Galaxy instances and API keys
- `add`: adds a new API key for a Galaxy instance
- `update`: updates an existing entry for a Galaxy instance
- `remove`: deletes an entry for a Galaxy instance

The PR aims to address issue #3 ("Easier management of API keys within nebulizer")
