### PR TITLE
Fix "manage_tools installed --list-tools" to match tools to repo revisions

### DIFF
--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -559,12 +559,16 @@ def list_installed_repositories(gi,name=None,
                                     revision.revision_id,
                                     revision.status))
             nrevisions += 1
-            # Get tools associated with repo
+            # List tools associated with revision
             if list_tools:
-                for tool in filter(lambda t: t.tool_repo == repo.id,tools):
+                repo_tools = filter(lambda t:
+                                    t.tool_repo == repo.id and
+                                    t.tool_changeset == revision.installed_changeset_revision,
+                                    tools)
+                for tool in repo_tools:
                     print "- %s" % '\t'.join((tool.name,
-                                              tool.version,
-                                              tool.description))
+                                               tool.version,
+                                               tool.description))
     print "total %s" % nrevisions
 
 def list_tool_panel(gi,name=None,list_tools=False):

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -130,6 +130,7 @@ class RepositoryRevision:
         # Version numbers
         self.revision_number = repo_data['ctx_rev']
         self.changeset_revision = repo_data['changeset_revision']
+        self.installed_changeset_revision = repo_data['installed_changeset_revision']
         self.status = repo_data['status']
         self.deleted = repo_data['deleted']
         # Repository revision status

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -42,6 +42,10 @@ class Tool:
         self.version = tool_data['version']
         self.description = tool_data['description']
         self.panel_section = tool_data['panel_section_name']
+        try:
+            self.config_file = tool_data['config_file']
+        except KeyError:
+            self.config_file = None
 
     @property
     def tool_repo(self):
@@ -67,6 +71,35 @@ class Tool:
             return '/'.join((toolshed,owner,repo))
         except ValueError:
             return ''
+
+    @property
+    def tool_changeset(self):
+        """
+        Return the tool changeset revision
+
+        This is a commit id of the form 'efc56ee1ade4'
+
+        Returns None if a changeset revision can't be
+        extracted
+
+        """
+        tool_repo = self.tool_repo
+        if not tool_repo:
+            return None
+        # Look for the config_file element - something of
+        # the form:
+        # .../toolshed.g2.bx.psu.edu/repos/devteam/picard/efc56ee1ade4/...
+        try:
+            ele = tool_repo.split('/')
+            toolshed = '/'.join(ele[:-2])
+            owner = ele[-2]
+            repo = ele[-1]
+            search_string = "/repos/%s/%s/" % (owner,repo)
+            i = self.config_file.index(search_string) + len(search_string)
+            revision = self.config_file[i:].split('/')[0]
+            return revision
+        except AttributeError,ValueError:
+            return None
 
 class RepositoryRevision:
     """

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -476,10 +476,13 @@ def list_tools(gi,name=None,installed_only=False):
     tools.sort(key=lambda x: x.name.lower())
     # Print info
     for tool in tools:
-        print "%-16s\t%-8s\t%-16s\t%s" % (tool.name,
-                                          tool.version,
-                                          tool.panel_section,
-                                          tool.tool_repo)
+        print "%-16s\t%-8s\t%-16s\t%s\t%s" % (tool.name,
+                                              tool.version,
+                                              tool.panel_section,
+                                              tool.tool_repo,
+                                              (tool.tool_changeset
+                                               if tool.tool_changeset
+                                               else ''))
     print "total %s" % len(tools)
 
 def list_installed_repositories(gi,name=None,

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -143,6 +143,8 @@ class TestRepository(unittest.TestCase):
         self.assertEqual(len(revisions),1)
         self.assertEqual(revisions[0].revision_number,'2')
         self.assertEqual(revisions[0].changeset_revision,'a60283899c6d')
+        self.assertEqual(revisions[0].installed_changeset_revision,
+                         'a60283899c6d')
         self.assertEqual(revisions[0].status,'Installed')
         self.assertFalse(revisions[0].deleted)
         self.assertFalse(revisions[0].revision_update)
@@ -201,6 +203,8 @@ class TestRepository(unittest.TestCase):
         self.assertEqual(len(revisions),2)
         self.assertEqual(revisions[0].revision_number,'2')
         self.assertEqual(revisions[0].changeset_revision,'a60283899c6d')
+        self.assertEqual(revisions[0].installed_changeset_revision,
+                         'a60283899c6d')
         self.assertEqual(revisions[0].status,'Installed')
         self.assertFalse(revisions[0].deleted)
         self.assertFalse(revisions[0].revision_update)
@@ -210,6 +214,8 @@ class TestRepository(unittest.TestCase):
         # Previous revision
         self.assertEqual(revisions[1].revision_number,'1')
         self.assertEqual(revisions[1].changeset_revision,'2bd7cdbb6228')
+        self.assertEqual(revisions[1].installed_changeset_revision,
+                         '3358c3d30143')
         self.assertEqual(revisions[1].status,'Installed')
         self.assertFalse(revisions[1].deleted)
         self.assertFalse(revisions[1].revision_update)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -13,7 +13,8 @@ class TestTool(unittest.TestCase):
     """
     def test_load_tool_data(self):
         tool_data = { u'panel_section_name': u'NGS: Mapping',
-                      u'description': u'Reports on methylation status of reads mapped by Bismark', 
+                      u'description': u'Reports on methylation status of reads mapped by Bismark',
+                      u'config_file': u'/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/bismark/0f8646f22b8d/bismark/bismark_bowtie_wrapper.xml',
                       u'name': u'Bismark Meth. Extractor',
                       u'panel_section_id': u'solexa_tools',
                       u'version': u'0.10.2',
@@ -34,6 +35,80 @@ class TestTool(unittest.TestCase):
                          'bismark_methylation_extractor/0.10.2')
         self.assertEqual(tool.tool_repo,
                          'toolshed.g2.bx.psu.edu/bgruening/bismark')
+        self.assertEqual(tool.tool_changeset,'0f8646f22b8d')
+
+    def test_load_tool_data_no_config_file(self):
+        tool_data = { u'panel_section_name': u'NGS: Mapping',
+                      u'description': u'Reports on methylation status of reads mapped by Bismark',
+                      u'name': u'Bismark Meth. Extractor',
+                      u'panel_section_id': u'solexa_tools',
+                      u'version': u'0.10.2',
+                      u'link': u'/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fbismark%2Fbismark_methylation_extractor%2F0.10.2',
+                      u'min_width': -1,
+                      u'model_class': u'Tool',
+                      u'id': u'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.10.2',
+                      u'target': u'galaxy_main'}
+        tool = Tool(tool_data)
+        self.assertEqual(tool.name,'Bismark Meth. Extractor')
+        self.assertEqual(tool.description,
+                         'Reports on methylation status of reads mapped by '
+                         'Bismark')
+        self.assertEqual(tool.version,'0.10.2')
+        self.assertEqual(tool.panel_section,'NGS: Mapping')
+        self.assertEqual(tool.id,
+                         'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/'
+                         'bismark_methylation_extractor/0.10.2')
+        self.assertEqual(tool.tool_repo,
+                         'toolshed.g2.bx.psu.edu/bgruening/bismark')
+        self.assertEqual(tool.tool_changeset,None)
+
+    def test_load_tool_data_toolshed_has_prefix(self):
+        tool_data = { u'panel_section_name': u'Local Toolshed',
+                      u'config_file': u'/galaxy/shed_tools/192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/2f0a1f1a5725/rnachipintegrator/rnachipintegrator_wrapper.xml',
+                      u'description': u"Integrated analysis of 'gene' and 'peak' data",
+                      u'panel_section_id': u'local_toolshed',
+                      u'version': u'1.0.1.0',
+                      u'link': u'/galaxy_dev/tool_runner?tool_id=192.168.60.164%2Ftoolshed%2Frepos%2Fpjbriggs%2Frnachipintegrator%2Frnachipintegrator_wrapper%2F1.0.1.0',
+                      u'target': u'galaxy_main',
+                      u'min_width': -1,
+                      u'model_class': u'Tool',
+                      u'id': u'192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.1.0',
+                      u'name': u'RnaChipIntegrator'}
+        tool = Tool(tool_data)
+        self.assertEqual(tool.name,'RnaChipIntegrator')
+        self.assertEqual(tool.description,
+                         "Integrated analysis of 'gene' and 'peak' data")
+        self.assertEqual(tool.version,'1.0.1.0')
+        self.assertEqual(tool.panel_section,'Local Toolshed')
+        self.assertEqual(tool.id,
+                         '192.168.60.164/toolshed/repos/pjbriggs/'
+                         'rnachipintegrator/rnachipintegrator_wrapper/1.0.1.0')
+        self.assertEqual(tool.tool_repo,
+                         '192.168.60.164/toolshed/pjbriggs/'
+                         'rnachipintegrator')
+        self.assertEqual(tool.tool_changeset,'2f0a1f1a5725')
+
+    def test_load_tool_data_not_from_toolshed(self):
+        tool_data = { u'panel_section_name': u'Get Genomic Scores',
+                      u'config_file': u'/galaxy/tools/filters/wiggle_to_simple.xml',
+                      u'description': u'converter',
+                      u'panel_section_id': u'scores',
+                      u'version': u'1.0.0',
+                      u'link': u'/galaxy_dev/tool_runner?tool_id=wiggle2simple1',
+                      u'target': u'galaxy_main',
+                      u'min_width': -1,
+                      u'model_class': u'Tool',
+                      u'id': u'wiggle2simple1',
+                      u'name': u'Wiggle-to-Interval' }
+        tool = Tool(tool_data)
+        self.assertEqual(tool.name,'Wiggle-to-Interval')
+        self.assertEqual(tool.description,
+                         'converter')
+        self.assertEqual(tool.version,'1.0.0')
+        self.assertEqual(tool.panel_section,'Get Genomic Scores')
+        self.assertEqual(tool.id,'wiggle2simple1')
+        self.assertEqual(tool.tool_repo,'')
+        self.assertEqual(tool.tool_changeset,None)
 
 class TestRepository(unittest.TestCase):
     """


### PR DESCRIPTION
PR attempting to address issue #10 by attempting to match tools to the correct installed repository revision for `manage_tools installed --list-tools`.

The fix works by extracting a changeset revision for a tool from the `config_file` attribute, which appears to be essentially a path to the XML file associated with the tool. This changeset revision is then matched against the _installed_ repository revision changeset to determine if the tool belongs to that revision. 

The installed revision changeset id is used because this seems to match the tool changeset revision, which is based on the installation path of the tool. This installed changeset id used can differ from the 'true' changeset revision, which I believe happens when a tool is installed at one revision and then updated via the Galaxy Admin interface to a new revision which doesn't change the tool version - in these cases the new files are installed under the existing path (which keeps the original changeset).

The fix feels potentially fragile as it relies on being able to extract a changeset revision from the `config_file` attribute, which might not always be present or in a form which contains a changeset revision which can be extracted; however it does seem to give better output than the previous version.
