### PR TITLE
Enable installation of multiple tool repositories from list in a file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,7 @@ Tool management:
  * ``list_tool_panel``: List tool panel contents.
  * ``list_installed_tools``: List installed tool repositories.
  * ``install_tool``: Install tool from toolshed.
+ * ``install_tools_from_file``: Install tools listed in a file.
  * ``update_tool``: Update tool installed from toolshed.
 
 Local API key management:
@@ -176,6 +177,12 @@ Install the most recent FastQC from the main toolshed::
 Update FastQC tool to latest installable revision::
 
   nebulizer update_tool localhost toolshed.g2.bx.psu.edu devteam fastqc
+
+Fetch a list of tools in one Galaxy instance and install them into
+another automatically::
+
+  nebulizer list_installed_tools old_galaxy --tsv > tools.tsv
+  nebulizer install_tools_from_file new_galaxy tools.tsv
 
 Managing Galaxy API keys
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,11 @@ Tool management:
  * ``list_tool_panel``: List tool panel contents.
  * ``list_installed_tools``: List installed tool repositories.
  * ``install_tool``: Install tool from toolshed.
- * ``install_tools_from_file``: Install tools listed in a file.
- * ``update_tool``: Update tool installed from toolshed.
+
+Bulk tool management:
+
+ * ``list_repositories``: List installed tool repos for (re)install.
+ * ``install_repositories``: Install tool repositories listed in a file.
 
 Local API key management:
 
@@ -181,8 +184,8 @@ Update FastQC tool to latest installable revision::
 Fetch a list of tools in one Galaxy instance and install them into
 another automatically::
 
-  nebulizer list_installed_tools old_galaxy --tsv > tools.tsv
-  nebulizer install_tools_from_file new_galaxy tools.tsv
+  nebulizer list_repositories old_galaxy > tools.tsv
+  nebulizer install_repositories new_galaxy tools.tsv
 
 Managing Galaxy API keys
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -528,37 +528,28 @@ def list_tools(context,galaxy,name,installed_only):
 @click.option('--updateable',is_flag=True,
               help="only show repositories with uninstalled updates "
               "or upgrades.")
-@click.option('--tsv',is_flag=True,
-              help="output in a tab-delimited value format with one "
-              "installed revision per line, columns are: toolshed, "
-              "owner, repository, changeset revision and tool panel "
-              "section. This output format is suitable for input "
-              "into the 'install_tools_from_file' command.")
 @click.argument("galaxy")
 @pass_context
 def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
-                         updateable,tsv):
+                         updateable):
     """
     List installed tool repositories.
 
     Prints details of installed tool repositories in GALAXY
     instance.
 
-    By default this is a 'verbose' format that includes:
-    repository name, toolshed, owner, revision id and changeset,
-    and installation status.
+    For each installed repository the details include: repository
+    name, toolshed, owner, revision id and changeset, and
+    installation status.
 
-    In this format, the repository details are also preceeded by
-    a single-character 'status' indicator ('D' = deprecated;
-    '^' = newer revision installed; 'u' = update available but
-    not installed; 'U' = ugrade available but not installed;
-    '*' = latest revision).
+    Repository details are also preceeded by a single-character
+    'status' indicator ('D' = deprecated; '^' = newer revision
+    installed; 'u' = update available but not installed; 'U' =
+    upgrade available but not installed; '*' = latest revision).
 
-    If the --tsv option is specified then the output is in a
-    more compact tab-delimited value format, with each line
-    containing just the toolshed, owner, repository, changeset
-    id and tool panel section. Output from this format is
-    suitable for input into 'install_tools_from_file' command.
+    If the --list-tools option is specified then additionally
+    after each repository the tools associated with the repository
+    will be listed along with their descriptions and versions.
     """
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
@@ -638,12 +629,55 @@ def install_tool(context,galaxy,toolshed,owner,repository,
         tool_panel_section=tool_panel_section)
 
 @nebulizer.command()
+@click.option('--name',metavar='NAME',
+              help="only list tool repositories matching NAME. Can "
+              "include glob-style wild-cards.")
+@click.option('--toolshed',metavar='TOOLSHED',
+              help="only list repositories installed from toolshed "
+              "matching TOOLSHED. Can include glob-style wild-cards.")
+@click.option('--owner',metavar='OWNER',
+              help="only list repositories from matching OWNER. "
+              "Can include glob-style wild-cards.")
+@click.option('--updateable',is_flag=True,
+              help="only show repositories with uninstalled updates "
+              "or upgrades.")
+@click.argument("galaxy")
+@pass_context
+def list_repositories(context,galaxy,name,toolshed,owner,updateable):
+    """
+    List installed tool repos for (re)install.
+
+    Prints details of installed tool repositories in GALAXY
+    instance in a format suitable for input into the
+    'install_repositories' command.
+
+    The output is a set of tab-delimited values, with each line
+    consisting of:
+
+    TOOLSHED|OWNER|REPOSITORY|CHANGESET|TOOL_PANEL_SECTION
+
+    The tool panel section will be empty if the repository
+    was installed outside of any section in the tool panel.
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logging.critical("Failed to connect to Galaxy instance")
+        return 1
+    # List repositories
+    tools.list_installed_repositories(gi,name=name,
+                                      toolshed=toolshed,
+                                      owner=owner,
+                                      only_updateable=updateable,
+                                      tsv=True)
+
+@nebulizer.command()
 @click.argument("galaxy")
 @click.argument("file",type=click.File('r'))
 @pass_context
-def install_tools_from_file(context,galaxy,file):
+def install_repositories(context,galaxy,file):
     """
-    Install tools listed in a file.
+    Install tool repositories listed in a file.
 
     Installs the tools specified in FILE into GALAXY.
 
@@ -675,10 +709,14 @@ def install_tools_from_file(context,galaxy,file):
             return 1
         try:
             revision = line[3]
+            if not revision:
+                revision = None
         except KeyError:
             revision = None
         try:
             tool_panel_section = line[4]
+            if not tool_panel_section:
+                tool_panel_section = None
         except KeyError:
             tool_panel_section = None
         tools.install_tool(gi,toolshed,repository,owner,

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -527,23 +527,38 @@ def list_tools(context,galaxy,name,installed_only):
               "installed repository revision changeset.")
 @click.option('--updateable',is_flag=True,
               help="only show repositories with uninstalled updates "
-              "or upgrades")
+              "or upgrades.")
+@click.option('--tsv',is_flag=True,
+              help="output in a tab-delimited value format with one "
+              "installed revision per line, columns are: toolshed, "
+              "owner, repository, changeset revision and tool panel "
+              "section. This output format is suitable for input "
+              "into the 'install_tools_from_file' command.")
 @click.argument("galaxy")
 @pass_context
 def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
-                         updateable):
+                         updateable,tsv):
     """
     List installed tool repositories.
 
     Prints details of installed tool repositories in GALAXY
-    instance, including: repository name, toolshed, owner,
-    revision id and changeset, and installation status.
+    instance.
 
-    Repository details are also preceeded by a single-character
-    'status' indicator: 'D' = deprecated; '^' = newer revision
-    installed; 'u' = update available but not installed;
-    'U' = ugrade available but not installed; '*' = latest
-    revision.
+    By default this is a 'verbose' format that includes:
+    repository name, toolshed, owner, revision id and changeset,
+    and installation status.
+
+    In this format, the repository details are also preceeded by
+    a single-character 'status' indicator ('D' = deprecated;
+    '^' = newer revision installed; 'u' = update available but
+    not installed; 'U' = ugrade available but not installed;
+    '*' = latest revision).
+
+    If the --tsv option is specified then the output is in a
+    more compact tab-delimited value format, with each line
+    containing just the toolshed, owner, repository, changeset
+    id and tool panel section. Output from this format is
+    suitable for input into 'install_tools_from_file' command.
     """
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -658,6 +658,9 @@ def list_repositories(context,galaxy,name,toolshed,owner,updateable):
 
     The tool panel section will be empty if the repository
     was installed outside of any section in the tool panel.
+
+    The repositories are ordered according to their position
+    in the tool panel.
     """
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -184,7 +184,7 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
         stored_key = None
     if api_key is None:
         api_key = stored_key
-    print "Connecting to %s" % galaxy_url
+    print "## Connecting to %s" % galaxy_url
     if email is not None:
         gi = galaxy.GalaxyInstance(url=galaxy_url,email=email,
                                    password=password)
@@ -198,9 +198,9 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
         return None
     try:
         user = galaxy.users.UserClient(gi).get_current_user()
-        print "Connected as user %s" % user['email']
+        print "## Connected as user %s" % user['email']
     except ConnectionError:
-        print "Unable to determine associated user"
+        print "## Unable to determine associated user"
     return gi
 
 def turn_off_urllib3_warnings():

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -335,6 +335,27 @@ class ToolPanelSection:
         """
         self.id = tool_panel_data['id']
         self.name = tool_panel_data['name']
+        self.model_class = tool_panel_data['model_class']
+        self.elems = []
+        try:
+            for elem in tool_panel_data['elems']:
+                self.elems.append(ToolPanelSection(elem))
+        except KeyError:
+            pass
+
+    @property
+    def is_toolsection(self):
+        """
+        Check if section is a tool panel section
+        """
+        return (self.model_class == "ToolSection")
+
+    @property
+    def is_tool(self):
+        """
+        Check if section is a tool
+        """
+        return (self.model_class == "Tool")
 
 # Functions
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -275,7 +275,6 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertEqual(section.model_class,'Tool')
         self.assertFalse(section.is_toolsection)
         self.assertTrue(section.is_tool)
-        self.assertEqual(section.is_tool)
         self.assertEqual(len(section.elems),0)
 
 class TestNormaliseToolshedUrl(unittest.TestCase):

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -270,7 +270,7 @@ class TestToolPanelSection(unittest.TestCase):
                             u'id': u'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65',
                             u'target': u'galaxy_main' }
         section = ToolPanelSection(tool_panel_data)
-        self.assertEqual(section.name,None)
+        self.assertEqual(section.name,'FastQC')
         self.assertEqual(section.id,'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65')
         self.assertEqual(section.model_class,'Tool')
         self.assertFalse(section.is_toolsection)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -226,7 +226,7 @@ class TestRepository(unittest.TestCase):
 class TestToolPanelSection(unittest.TestCase):
     """
     """
-    def test_load_tool_panel_data(self):
+    def test_load_tool_panel_data_for_toolsection(self):
         tool_panel_data = { u'model_class': u'ToolSection',
                             u'version': u'',
                             u'elems':
@@ -245,6 +245,38 @@ class TestToolPanelSection(unittest.TestCase):
         section = ToolPanelSection(tool_panel_data)
         self.assertEqual(section.name,'NGS: SAM Tools')
         self.assertEqual(section.id,'ngs:_sam_tools')
+        self.assertEqual(section.model_class,'ToolSection')
+        self.assertTrue(section.is_toolsection)
+        self.assertFalse(section.is_tool)
+        self.assertEqual(len(section.elems),1)
+        self.assertEqual(section.elems[0].name,'MPileup')
+        self.assertEqual(section.elems[0].id,'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.0')
+        self.assertEqual(section.elems[0].model_class,'Tool')
+        self.assertFalse(section.elems[0].is_toolsection)
+        self.assertTrue(section.elems[0].is_tool)
+        self.assertEqual(len(section.elems[0].elems),0)
+
+    def test_load_tool_panel_data_for_tool(self):
+        tool_panel_data = { u'panel_section_name': None,
+                            u'config_file': u'/mnt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/3fdc1a74d866/fastqc/rgFastQC.xml',
+                            u'description': u'Read Quality reports',
+                            u'labels': [],
+                            u'name': u'FastQC',
+                            u'panel_section_id': None,
+                            u'version': u'0.65',
+                            u'link': u'/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Ffastqc%2Ffastqc%2F0.65',
+                            u'min_width': -1,
+                            u'model_class': u'Tool',
+                            u'id': u'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65',
+                            u'target': u'galaxy_main' }
+        section = ToolPanelSection(tool_panel_data)
+        self.assertEqual(section.name,None)
+        self.assertEqual(section.id,'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65')
+        self.assertEqual(section.model_class,'Tool')
+        self.assertFalse(section.is_toolsection)
+        self.assertTrue(section.is_tool)
+        self.assertEqual(section.is_tool)
+        self.assertEqual(len(section.elems),0)
 
 class TestNormaliseToolshedUrl(unittest.TestCase):
     """


### PR DESCRIPTION
PR which implements two new commands in `nebulizer`, in order to make it easier to install a set of tools into a Galaxy instance based on tools already installed elsewhere.
- `list_repositories`: generates a TSV file with a list of the repositories from a Galaxy instance
- `install_repositories`: installs repositories from TSV with the same format as above into a Galaxy instance.
