### PR TITLE
Fix reporting of target tool panel in 'tools.install_tool'

### DIFF
--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -833,21 +833,29 @@ def install_tool(gi,tool_shed,name,owner,
         # Set revision to the most recent
         revision = revisions[-1]
         print "Installing newest revision (%s)" % revision
-    # Look up tool panel
+    # Check if tool is already installed
+    install_status = tool_install_status(gi,tool_shed,owner,name,
+                                         revision)
+    if install_status.startswith("Installed"):
+        print "%s: already installed (status is \"%s\")" % (name,
+                                                            install_status)
+        return TOOL_INSTALL_OK
+    # Look up tool panel section
     tool_panel_section_id = None
     if tool_panel_section is not None:
         for section in get_tool_panel_sections(gi):
             if tool_panel_section == section.id or \
                tool_panel_section == section.name:
                 tool_panel_section_id = section.id
-                print "Existing tool panel section: '%s' (id '%s')" % \
-                    (section.name,tool_panel_section_id)
                 break
         if not tool_panel_section_id:
             print "New tool panel section: '%s'" % tool_panel_section
         else:
-            print "No tool panel section specified"
+            print "Existing tool panel section: '%s' (id '%s')" % \
+                (section.name,tool_panel_section_id)
             tool_panel_section = None
+    else:
+        print "No tool panel section specified"
     # Get toolshed URL
     tool_shed_url = normalise_toolshed_url(tool_shed)
     print "Toolshed URL: %s" % tool_shed_url

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -842,20 +842,25 @@ def install_tool(gi,tool_shed,name,owner,
         return TOOL_INSTALL_OK
     # Look up tool panel section
     tool_panel_section_id = None
-    if tool_panel_section is not None:
+    new_tool_panel_section = None
+    if tool_panel_section is None:
+        print "Installing into top level tool panel (no section specified)"
+    else:
+        # Look for an existing section which matches the
+        # supplied name or id
         for section in get_tool_panel_sections(gi):
             if tool_panel_section == section.id or \
                tool_panel_section == section.name:
+                # Found existing tool panel section
                 tool_panel_section_id = section.id
+                print "Installing into existing tool panel section: " \
+                    "'%s' (id '%s')" % (section.name,tool_panel_section_id)
                 break
         if not tool_panel_section_id:
-            print "New tool panel section: '%s'" % tool_panel_section
-        else:
-            print "Existing tool panel section: '%s' (id '%s')" % \
-                (section.name,tool_panel_section_id)
-            tool_panel_section = None
-    else:
-        print "No tool panel section specified"
+            # No matching section exists, make a new one
+            print "Installing into new tool panel section: '%s'" % \
+                tool_panel_section
+            new_tool_panel_section = tool_panel_section
     # Get toolshed URL
     tool_shed_url = normalise_toolshed_url(tool_shed)
     print "Toolshed URL: %s" % tool_shed_url
@@ -868,7 +873,7 @@ def install_tool(gi,tool_shed,name,owner,
             install_tool_dependencies=True,
             install_repository_dependencies=True,
             tool_panel_section_id=tool_panel_section_id,
-            new_tool_panel_section_label=tool_panel_section)
+            new_tool_panel_section_label=new_tool_panel_section)
     except ConnectionError,ex:
         print "Error from Galaxy API: %s (ignored)" % ex
     # Check installation status


### PR DESCRIPTION
PR that fixes the reporting of the target tool panel section in the `tools.install_tool` function - the message could incorrect report that no section was targeted when attempting to install to an existing section. In these cases the outcome was still correct however.
