### PR TITLE
Update 'ToolPanelSection' class to handle tool panel labels

### DIFF
--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -334,7 +334,10 @@ class ToolPanelSection:
 
         """
         self.id = tool_panel_data['id']
-        self.name = tool_panel_data['name']
+        try:
+            self.name = tool_panel_data['name']
+        except KeyError:
+            self.name = None
         self.model_class = tool_panel_data['model_class']
         self.elems = []
         try:
@@ -356,6 +359,13 @@ class ToolPanelSection:
         Check if section is a tool
         """
         return (self.model_class == "Tool")
+
+    @property
+    def is_label(self):
+        """
+        Check if section is a tool panel label
+        """
+        return (self.model_class == "ToolSectionLabel")
 
 class ToolPanel:
     """

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -248,12 +248,14 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertEqual(section.model_class,'ToolSection')
         self.assertTrue(section.is_toolsection)
         self.assertFalse(section.is_tool)
+        self.assertFalse(section.is_label)
         self.assertEqual(len(section.elems),1)
         self.assertEqual(section.elems[0].name,'MPileup')
         self.assertEqual(section.elems[0].id,'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.0')
         self.assertEqual(section.elems[0].model_class,'Tool')
         self.assertFalse(section.elems[0].is_toolsection)
         self.assertTrue(section.elems[0].is_tool)
+        self.assertFalse(section.elems[0].is_label)
         self.assertEqual(len(section.elems[0].elems),0)
 
     def test_load_tool_panel_data_for_tool(self):
@@ -275,6 +277,21 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertEqual(section.model_class,'Tool')
         self.assertFalse(section.is_toolsection)
         self.assertTrue(section.is_tool)
+        self.assertFalse(section.is_label)
+        self.assertEqual(len(section.elems),0)
+
+    def test_load_tool_panel_data_for_label(self):
+        tool_panel_data = { u'model_class': u'ToolSectionLabel',
+                            u'version': u'',
+                            u'id': u'deprecated',
+                            u'text': u'DEPRECATED' }
+        section = ToolPanelSection(tool_panel_data)
+        self.assertEqual(section.name,None)
+        self.assertEqual(section.id,'deprecated')
+        self.assertEqual(section.model_class,'ToolSectionLabel')
+        self.assertFalse(section.is_toolsection)
+        self.assertFalse(section.is_tool)
+        self.assertTrue(section.is_label)
         self.assertEqual(len(section.elems),0)
 
 class TestNormaliseToolshedUrl(unittest.TestCase):


### PR DESCRIPTION
PR which fixes the `ToolPanelSection` class to handle 'label' sections in the tool panel of the target Galaxy instance (previously these would crash Nebulizer).
