### PR TITLE
install_tool command: consider tool with status "New" as still be installing

### DIFF
--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -956,6 +956,7 @@ def install_tool(gi,tool_shed,name,owner,
                                                         install_status)
             return TOOL_INSTALL_OK
         elif install_status.startswith("Installing") or \
+             install_status == "New" or \
              install_status == "Cloning" or \
              install_status == "Never installed":
             ntries += 1


### PR DESCRIPTION
PR to modify the `install_tool` command (and underlying function) so that tools with the status `New` will be considered as installing.

This situation can arise for tools with large numbers of dependencies which need to be installed first.