### PR TITLE
Switch logging over to using per-module loggers WIP

### DIFF
--- a/nebulizer/__init__.py
+++ b/nebulizer/__init__.py
@@ -6,3 +6,8 @@ def get_version():
 
     """
     return __version__
+
+# Setup logging
+import logging
+logging.basicConfig()
+logger = logging.getLogger("nebulizer")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -15,6 +15,8 @@ import users
 import libraries
 import tools
 
+logger = logging.getLogger(__name__)
+
 def handle_ssl_warnings(verify=True):
     """
     Turn off SSL warnings from urllib3
@@ -25,8 +27,8 @@ def handle_ssl_warnings(verify=True):
 
     """
     if not verify:
-        logging.warning("SSL certificate verification has "
-                        "been disabled")
+        logger.warning("SSL certificate verification has "
+                       "been disabled")
         turn_off_urllib3_warnings()
 
 def handle_debug(debug=True):
@@ -38,9 +40,10 @@ def handle_debug(debug=True):
 
     """
     if debug:
-        logging.getLogger().setLevel(logging.DEBUG)
+        level = logging.DEBUG
     else:
-        logging.getLogger().setLevel(logging.WARNING)
+        level = logging.WARNING
+    logging.getLogger("nebulizer").setLevel(level)
 
 def handle_suppress_warnings(suppress_warnings=True):
     """
@@ -52,9 +55,7 @@ def handle_suppress_warnings(suppress_warnings=True):
 
     """
     if suppress_warnings:
-        logging.getLogger().setLevel(logging.ERROR)
-    else:
-        logging.getLogger().setLevel(logging.WARNING)
+        logging.getLogger("nebulizer").setLevel(logging.ERROR)
 
 def handle_credentials(email,password,prompt="Password: "):
     """
@@ -205,14 +206,14 @@ def add_key(context,alias,galaxy_url,api_key=None):
     """
     instances = Credentials()
     if alias in instances.list_keys():
-        logging.error("'%s' already exists" % alias)
+        logger.error("'%s' already exists" % alias)
         return 1
     if api_key is None:
         # No API key supplied as argument, try to connect
         # to Galaxy and fetch directly
         gi = context.galaxy_instance(galaxy_url)
         if gi is None:
-            logging.critical("%s: failed to connect" % galaxy_url)
+            logger.critical("%s: failed to connect" % galaxy_url)
             return 1
         api_key = gi.key
     # Store the entry
@@ -236,7 +237,7 @@ def update_key(context,alias,new_url,new_api_key,fetch_api_key):
     """
     instances = Credentials()
     if alias not in instances.list_keys():
-        logging.error("'%s': not found" % alias)
+        logger.error("'%s': not found" % alias)
         return 1
     if new_url:
         galaxy_url = new_url
@@ -248,7 +249,7 @@ def update_key(context,alias,new_url,new_api_key,fetch_api_key):
         # Attempt to connect to Galaxy and fetch API key
         gi = context.galaxy_instance(alias)
         if gi is None:
-            logging.critical("%s: failed to connect" % alias)
+            logger.critical("%s: failed to connect" % alias)
             return 1
         new_api_key = gi.key
     instances.update_key(alias,
@@ -286,7 +287,7 @@ def list_users(context,galaxy,name,long_listing):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List users
     users.list_users(gi,name=name,long_listing_format=long_listing)
@@ -320,19 +321,19 @@ def create_user(context,galaxy,email,public_name,password,only_check,
     # Check message template is a .mako file
     if message_template:
         if not message_template.endswith(".mako"):
-            logging.critical("Message template '%s' is not a .mako file"
-                             % message_template)
+            logger.critical("Message template '%s' is not a .mako file"
+                            % message_template)
             return 1
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Sort out email and public name
     if public_name:
         if not users.check_username_format(public_name):
-            logging.critical("Invalid public name: must contain only "
-                             "lower-case letters, numbers and '-'")
+            logger.critical("Invalid public name: must contain only "
+                            "lower-case letters, numbers and '-'")
             return 1
     else:
         # No public name supplied, make from email address
@@ -381,7 +382,7 @@ def create_batch_users(context,galaxy,template,start,end,
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Sort out start and end indices
     if end is None:
@@ -418,13 +419,13 @@ def create_users_from_file(context,galaxy,file,message_template,
     # Check message template is a .mako file
     if message_template:
         if not message_template.endswith(".mako"):
-            logging.critical("Message template '%s' is not a .mako file"
-                             % message_template)
+            logger.critical("Message template '%s' is not a .mako file"
+                            % message_template)
             return 1
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Create users
     return users.create_batch_of_users(gi,file,
@@ -451,7 +452,7 @@ def list_tools(context,galaxy,name,installed_only):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List tools
     tools.list_tools(gi,name=name,installed_only=installed_only)
@@ -498,7 +499,7 @@ def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List repositories
     tools.list_installed_repositories(gi,name=name,
@@ -527,7 +528,7 @@ def list_tool_panel(context,galaxy,name,list_tools):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List tool panel contents
     tools.list_tool_panel(gi,name=name,
@@ -571,7 +572,7 @@ def install_tool(context,galaxy,toolshed,owner,repository,
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Install tool
     return tools.install_tool(
@@ -618,7 +619,7 @@ def list_repositories(context,galaxy,name,toolshed,owner,updateable):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List repositories
     tools.list_installed_repositories(gi,name=name,
@@ -656,7 +657,7 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Install tools
     for line in file:
@@ -667,7 +668,7 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
         try:
             toolshed,owner,repository = line[:3]
         except ValueError:
-            logging.critical("Couldn't parse line")
+            logger.critical("Couldn't parse line")
             return 1
         try:
             revision = line[3]
@@ -713,7 +714,7 @@ def update_tool(context,galaxy,toolshed,owner,repository):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Install tool
     return tools.update_tool(gi,toolshed,repository,owner,
@@ -739,7 +740,7 @@ def list_libraries(context,galaxy,path,long_listing):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # List folders in data library
     if path:
@@ -767,7 +768,7 @@ def create_library(context,galaxy,name,description,synopsis):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Create new data library
     libraries.create_library(gi,name,
@@ -795,7 +796,7 @@ def create_library_folder(context,galaxy,path,description):
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Create new folder
     libraries.create_folder(gi,path,description=description)
@@ -836,7 +837,7 @@ def add_library_datasets(context,galaxy,dest,file,file_type,
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     # Add the datasets
     libraries.add_library_datasets(gi,dest,file,
@@ -900,13 +901,14 @@ def whoami(context,galaxy,):
     """
     Print user details associated with API key.
     """
+    logger.debug("Debugging mode")
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         return 1
     user = get_current_user(gi)
     if user is None:
-        logging.warning("No associated user for this API key")
+        logger.warning("No associated user for this API key")
     else:
         click.echo("%s" % user['email'])

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -10,6 +10,8 @@ import time
 from bioblend import galaxy
 from bioblend.galaxy.client import ConnectionError
 
+logger = logging.getLogger(__name__)
+
 class Credentials:
     """Class for managing credentials for Galaxy instances
 
@@ -84,7 +86,7 @@ class Credentials:
         """
         key_names = self.list_keys()
         if name not in key_names:
-            logging.error("'%s': not found" % name)
+            logger.error("'%s': not found" % name)
             return
         # Store the keys
         cached_keys = {
@@ -117,7 +119,7 @@ class Credentials:
         try:
             url,api_key = self.fetch_key(name)
         except KeyError:
-            logging.error("'%s': not found" % name)
+            logger.error("'%s': not found" % name)
             return
         if new_url:
             url = new_url
@@ -180,12 +182,12 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
     try:
         galaxy_url,stored_key = Credentials().fetch_key(galaxy_url)
     except KeyError,ex:
-        logging.warning("Failed to find credentials for %s" %
-                        galaxy_url)
+        logger.warning("Failed to find credentials for %s" %
+                       galaxy_url)
         stored_key = None
     if api_key is None:
         api_key = stored_key
-    logging.debug("Connecting to %s" % galaxy_url)
+    logger.debug("Connecting to %s" % galaxy_url)
     if email is not None:
         gi = galaxy.GalaxyInstance(url=galaxy_url,email=email,
                                    password=password)
@@ -196,9 +198,9 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
         return None
     user = get_current_user(gi)
     if user is not None:
-        logging.debug("Connected as user %s" % user['email'])
+        logger.debug("Connected as user %s" % user['email'])
     else:
-        logging.debug("Unable to determine associated user")
+        logger.debug("Unable to determine associated user")
     return gi
 
 def get_galaxy_config(gi):

--- a/nebulizer/deprecated_cli.py
+++ b/nebulizer/deprecated_cli.py
@@ -15,14 +15,14 @@ import users
 import libraries
 import tools
 
-logging.basicConfig(format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
 
 def deprecation_warning():
     """
     Issue a deprecation warning
     """
-    logging.warning("*********** THIS UTILITY IS NOW DEPRECATED ***********")
-    logging.warning("*********** Use 'nebulizer CMD...' instead ***********")
+    logger.warning("*********** THIS UTILITY IS NOW DEPRECATED ***********")
+    logger.warning("*********** Use 'nebulizer CMD...' instead ***********")
 
 def base_parser(usage=None,description=None):
     """
@@ -151,7 +151,7 @@ def manage_users(args=None):
                              email=email,password=password,
                              verify_ssl=(not options.no_verify))
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
 
     # Execute command
@@ -162,12 +162,12 @@ def manage_users(args=None):
         # Check message template is .mako file
         if options.message_template:
             if not os.path.isfile(options.message_template):
-                logging.critical("Message template '%s' not found"
-                                 % options.message_template)
+                logger.critical("Message template '%s' not found"
+                                % options.message_template)
                 sys.exit(1)
             elif not options.message_template.endswith(".mako"):
-                logging.critical("Message template '%s' is not a .mako file"
-                                 % options.message_template)
+                logger.critical("Message template '%s' is not a .mako file"
+                                % options.message_template)
                 sys.exit(1)
         if options.template:
             # Get the template and range of indices
@@ -194,9 +194,9 @@ def manage_users(args=None):
             try:
                 name = args[1]
                 if not users.check_username_format(name):
-                    logging.critical("Invalid name: must contain only "
-                                     "lower-case letters, numbers and "
-                                     "'-'")
+                    logger.critical("Invalid name: must contain only "
+                                    "lower-case letters, numbers and "
+                                    "'-'")
                     sys.exit(1)
             except IndexError:
                 # No public name supplied, make from email address
@@ -299,7 +299,7 @@ def manage_libraries(args=None):
                              email=email,password=password,
                              verify_ssl=(not options.no_verify))
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
 
     # Execute command
@@ -430,7 +430,7 @@ def manage_tools(args=None):
                              email=email,password=password,
                              verify_ssl=(not options.no_verify))
     if gi is None:
-        logging.critical("Failed to connect to Galaxy instance")
+        logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
 
     # Execute command

--- a/nebulizer/libraries.py
+++ b/nebulizer/libraries.py
@@ -7,6 +7,8 @@ import fnmatch
 from bioblend import galaxy
 import logging
 
+logger = logging.getLogger(__name__)
+
 def list_data_libraries(gi):
     """
     Return list of data libraries
@@ -52,10 +54,10 @@ def folder_id_from_name(gi,library_id,folder_name):
     """
     lib_client = galaxy.libraries.LibraryClient(gi)
     folder_name = normalise_folder_path(folder_name)
-    logging.debug("Looking for '%s' in library %s" % (folder_name,
+    logger.debug("Looking for '%s' in library %s" % (folder_name,
                                                       library_id))
     for folder in lib_client.get_folders(library_id):
-        logging.debug("Checking '%s'" % folder['name'])
+        logger.debug("Checking '%s'" % folder['name'])
         if folder['name'] == folder_name:
             return folder['id']
     return None
@@ -78,17 +80,17 @@ def list_library_contents(gi,path,long_listing_format=False):
 
     """
     # Get name and id for parent data library
-    logging.debug("Path '%s'" % path)
+    logger.debug("Path '%s'" % path)
     lib_client = galaxy.libraries.LibraryClient(gi)
     library_name,folder_path = split_library_path(path)
-    logging.debug("library_name '%s'" % library_name)
+    logger.debug("library_name '%s'" % library_name)
     library_id = library_id_from_name(gi,library_name)
     if library_id is None:
         print "No library '%s'" % library_name
         return
     # Get library contents
     library_contents = lib_client.show_library(library_id,contents=True)
-    logging.debug("folder_path '%s'" % folder_path)
+    logger.debug("folder_path '%s'" % folder_path)
     # Bioblend class for getting more info for datasets if
     # using a long listing format
     dataset_client = galaxy.datasets.DatasetClient(gi)
@@ -107,8 +109,8 @@ def list_library_contents(gi,path,long_listing_format=False):
         matches = filter(lambda x: x['name'] == pattern,
                          library_contents)
         if not matches:
-            logging.error("Cannot access %s: no matching libraries "
-                          "or folders" % path)
+            logger.error("Cannot access %s: no matching libraries "
+                         "or folders" % path)
             return
         for item in matches:
             if item['type'] == 'folder':
@@ -138,8 +140,8 @@ def list_library_contents(gi,path,long_listing_format=False):
                          and x['name'].count('/') == nlevels,
                          library_contents)
         if not matches:
-            logging.error("Cannot access %s: no matching libraries "
-                          "or folders\n" % path)
+            logger.error("Cannot access %s: no matching libraries "
+                         "or folders\n" % path)
             return
         # Identify the folders that are matched exactly
         folders = []
@@ -228,8 +230,8 @@ def create_folder(gi,path,description=None):
     """
     # Break up the path
     library_name,folder_path = split_library_path(path)
-    logging.debug("library_name: %s" % library_name)
-    logging.debug("folder_path : %s" % folder_path)
+    logger.debug("library_name: %s" % library_name)
+    logger.debug("folder_path : %s" % folder_path)
     # Get name and id for parent data library
     lib_client = galaxy.libraries.LibraryClient(gi)
     library_id = library_id_from_name(gi,library_name)
@@ -365,7 +367,7 @@ def report_folder(folder_data,long_listing=False):
         long listing format when reporting items
 
     """
-    logging.debug("%s" % folder_data)
+    logger.debug("%s" % folder_data)
     if long_listing:
         print "%s/\t%s\t%s" % (folder_data['name'],
                                 folder_data['description'],
@@ -384,7 +386,7 @@ def report_dataset(dataset_data,long_listing=False):
         long listing format when reporting items
 
     """
-    logging.debug("%s" % dataset_data)
+    logger.debug("%s" % dataset_data)
     if long_listing:
         print '\t'.join([str(x) for x in (dataset_data['name'],
                                           dataset_data['file_ext'],

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -8,6 +8,9 @@ import fnmatch
 from bioblend import galaxy
 from mako.template import Template
 
+# Logging
+logger = logging.getLogger(__name__)
+
 # Classes
 
 class User:
@@ -131,7 +134,7 @@ def create_user(gi,email,username=None,passwd=None,only_check=False,
         try:
             passwd = get_passwd()
         except Exception, ex:
-            logging.error("%s" % ex)
+            logger.error("%s" % ex)
             return 1
     # Create the new user
     try:
@@ -187,18 +190,18 @@ def create_users_from_template(gi,template,start,end,passwd=None,
     # Check template
     name,domain = template.split('@')
     if name.count('#') != 1 or domain.count('#') != 0:
-        logging.error("Incorrect email template format")
+        logger.error("Incorrect email template format")
         return 1
     # Deal with password
     if passwd is not None:
         if not validate_password(passwd):
-            logging.error("Invalid password")
+            logger.error("Invalid password")
             return 1
     else:
         try:
             passwd = get_passwd()
         except Exception, ex:
-            logging.error("%s" % ex)
+            logger.error("%s" % ex)
             return 1
     # Generate emails
     emails = [template.replace('#',str(i)) for i in range(start,end+1)]
@@ -272,13 +275,13 @@ def create_batch_of_users(gi,tsv,only_check=False,mako_template=None):
             pass
         # Do checks
         if email in users:
-            logging.error("%s: appears multiple times" % email)
+            logger.error("%s: appears multiple times" % email)
             return 1
         if passwd is None:
-            logging.error("%s: no password supplied" % email)
+            logger.error("%s: no password supplied" % email)
             return 1
         elif not validate_password(passwd):
-            logging.error("%s: invalid password\n" % email)
+            logger.error("%s: invalid password\n" % email)
             return 1
         if name is None:
             name = get_username_from_login(email)
@@ -309,7 +312,7 @@ def check_new_user_info(gi,email,username):
         for user in lookup_user:
             error_msg += "\n%s" % ('\t'.join([user.email,
                                              user.username]))
-        logging.error(error_msg)
+        logger.error(error_msg)
         return False
     return True
 
@@ -329,12 +332,12 @@ def get_user_api_key(gi,username=None):
             user = galaxy.users.UserClient(gi).get_current_user()
             print "Username: %s" % username
         except galaxy.client.ConnectionError:
-            logging.error("Cannot determine user associated with "
+            logger.error("Cannot determine user associated with "
                           "this instance")
             return
         except AttributeError:
-            logging.error("Unable to fetch user associated with "
-                          "this instance")
+            logger.error("Unable to fetch user associated with "
+                         "this instance")
             return
     else:
         # Fetch the details for the specified user
@@ -344,7 +347,7 @@ def get_user_api_key(gi,username=None):
                 user = u
                 break
     if user is None:
-        logging.error("Cannot get info for user '%s'\n" % username)
+        logger.error("Cannot get info for user '%s'\n" % username)
         return
     # Get the API key
     user_id = user.id


### PR DESCRIPTION
PR which reorganises logging from the nebulizer modules to use module-level loggers rather than the 'root' logger as before. It is intended to address issue #36.

These changes should pave the way for more control over the logging messages output from other libraries such as `bioblend` and `requests`, if necessary.