### PR TITLE
Bugfix to broken 'update_tool' command

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -716,7 +716,8 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
 @click.argument("owner")
 @click.argument("repository")
 @pass_context
-def update_tool(context,galaxy,toolshed,owner,repository):
+def update_tool(context,galaxy,toolshed,owner,repository,
+                timeout,no_wait):
     """
     Update tool installed from toolshed.
 


### PR DESCRIPTION
PR to fix the `update_tool` command, which was broken as the code hadn't been updated to properly handled the `timeout` and `nowait` options.