### PR TITLE
Sync tool versions against toolsheds for 'list_installed_tools' and 'update_tool'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,19 @@ Update FastQC tool to latest installable revision::
 
   nebulizer update_tool localhost toolshed.g2.bx.psu.edu devteam fastqc
 
+.. warning::
+
+   By default checks on the availability of updates for tools
+   performed by the ``list_installed_tools`` and ``update_tool``
+   commands are done using information cached by the Galaxy
+   instance in question. As a result these commands may not
+   always indicate when updates are available.
+
+   To force these commands to check the installed revisions
+   against those in the toolshed, add the ``--check-toolshed``
+   option. Note however that this can impose a significant
+   overhead which can make the commands much slower.
+
 ----------------------------------
 Checking status of a Galaxy server
 ----------------------------------

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -513,7 +513,7 @@ def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
     # List repositories
     sys.exit(tools.list_installed_repositories(
         gi,name=name,
-        toolshed=toolshed,
+        tool_shed=toolshed,
         owner=owner,
         list_tools=list_tools,
         only_updateable=updateable))
@@ -634,7 +634,7 @@ def list_repositories(context,galaxy,name,toolshed,owner,updateable):
     # List repositories
     sys.exit(tools.list_installed_repositories(
         gi,name=name,
-        toolshed=toolshed,
+        tool_shed=toolshed,
         owner=owner,
         only_updateable=updateable,
         tsv=True))

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -482,10 +482,14 @@ def list_tools(context,galaxy,name,installed_only):
 @click.option('--updateable',is_flag=True,
               help="only show repositories with uninstalled updates "
               "or upgrades.")
+@click.option('--check-toolshed',is_flag=True,
+              help="check installed revisions directly against those "
+              "available in the toolshed. NB this can be extremely "
+              "slow.")
 @click.argument("galaxy")
 @pass_context
 def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
-                         updateable):
+                         updateable,check_toolshed):
     """
     List installed tool repositories.
 
@@ -500,6 +504,14 @@ def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
     'status' indicator ('D' = deprecated; '^' = newer revision
     installed; 'u' = update available but not installed; 'U' =
     upgrade available but not installed; '*' = latest revision).
+
+    Note that there may still be a newer revision of a tool
+    available from the toolshed, even when the repository is
+    marked as '*'. Use the --check-toolshed option to also
+    explicitly check against the toolshed, in which case a '!'
+    status indicates that a newer version has been found on
+    toolshed. Note that this option incurs a significant overhead
+    when checking a large number of tools.
 
     If the --list-tools option is specified then additionally
     after each repository the tools associated with the repository
@@ -516,7 +528,8 @@ def list_installed_tools(context,galaxy,name,toolshed,owner,list_tools,
         tool_shed=toolshed,
         owner=owner,
         list_tools=list_tools,
-        only_updateable=updateable))
+        only_updateable=updateable,
+        check_tool_shed=check_toolshed))
 
 @nebulizer.command()
 @click.option('--name',metavar='NAME',
@@ -719,13 +732,16 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
 @click.option('--no-wait',is_flag=True,
               help="don't wait for lengthy tool installations to "
               "complete.")
+@click.option('--check-toolshed',is_flag=True,
+              help="check installed revisions directly against those "
+              "available in the toolshed")
 @click.argument("galaxy")
 @click.argument("toolshed")
 @click.argument("owner")
 @click.argument("repository")
 @pass_context
 def update_tool(context,galaxy,toolshed,owner,repository,
-                timeout,no_wait):
+                timeout,no_wait,check_toolshed):
     """
     Update tool installed from toolshed.
 
@@ -744,7 +760,8 @@ def update_tool(context,galaxy,toolshed,owner,repository,
         sys.exit(1)
     # Install tool
     sys.exit(tools.update_tool(gi,toolshed,repository,owner,
-                               timeout=timeout,no_wait=no_wait))
+                               timeout=timeout,no_wait=no_wait,
+                               check_tool_shed=check_toolshed))
 
 @nebulizer.command()
 @click.option('-l','long_listing',is_flag=True,

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -81,10 +81,10 @@ class Tool:
         ele = self.id.split('/')
         try:
             i = ele.index('repos')
-            toolshed = '/'.join(ele[:i])
+            tool_shed = '/'.join(ele[:i])
             owner = ele[i+1]
             repo = ele[i+2]
-            return '/'.join((toolshed,owner,repo))
+            return '/'.join((tool_shed,owner,repo))
         except ValueError:
             return ''
 
@@ -110,7 +110,7 @@ class Tool:
         # .../toolshed.g2.bx.psu.edu/repos/devteam/picard/efc56ee1ade4/...
         try:
             ele = tool_repo.split('/')
-            toolshed = '/'.join(ele[:-2])
+            tool_shed = '/'.join(ele[:-2])
             owner = ele[-2]
             repo = ele[-1]
             search_string = "/repos/%s/%s/" % (owner,repo)
@@ -558,12 +558,12 @@ def get_revisions_from_toolshed(tool_shed,name,owner):
                         (tool_shed,connection_error.status_code))
         return []
 
-def normalise_toolshed_url(toolshed):
+def normalise_toolshed_url(tool_shed):
     """
     Return complete URL for a tool shed
 
     Arguments:
-      toolshed (str): partial or full URL for a
+      tool_shed (str): partial or full URL for a
         toolshed server
 
     Returns:
@@ -571,10 +571,10 @@ def normalise_toolshed_url(toolshed):
         leading protocol.
 
     """
-    if toolshed.startswith('http://') or \
-       toolshed.startswith('https://'):
-        return toolshed
-    return "https://%s" % toolshed
+    if tool_shed.startswith('http://') or \
+       tool_shed.startswith('https://'):
+        return tool_shed
+    return "https://%s" % tool_shed
 
 def tool_install_status(gi,tool_shed,owner,name,revision=None):
     """
@@ -626,7 +626,7 @@ def tool_install_status(gi,tool_shed,owner,name,revision=None):
     return rev.status
 
 def installed_repositories(gi,name=None,
-                           toolshed=None,
+                           tool_shed=None,
                            owner=None,
                            include_deleted=False,
                            only_updateable=False):
@@ -637,7 +637,7 @@ def installed_repositories(gi,name=None,
       gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
       name (str): optional, only list tool repositiories
         which match this string (can include wildcards)
-      toolshed (str): optional, only list tool
+      tool_shed (str): optional, only list tool
         repositories from toolsheds that match this string
         (can include wildcards)
       owner (str): optional, only list tool repositiories
@@ -671,12 +671,12 @@ def installed_repositories(gi,name=None,
         repos = filter(lambda r: fnmatch.fnmatch(r.name.lower(),name),
                        repos)
     # Filter on toolshed
-    if toolshed:
+    if tool_shed:
         # Strip leading http(s)://
         for protocol in ('https://','http://'):
-            if toolshed.startswith(protocol):
-                toolshed = toolshed[len(protocol):]
-        repos = filter(lambda r: fnmatch.fnmatch(r.tool_shed,toolshed),
+            if tool_shed.startswith(protocol):
+                tool_shed = tool_shed[len(protocol):]
+        repos = filter(lambda r: fnmatch.fnmatch(r.tool_shed,tool_shed),
                        repos)
     # Filter on owner
     if owner:
@@ -744,7 +744,7 @@ def list_tools(gi,name=None,installed_only=False):
     print "total %s" % len(tools)
 
 def list_installed_repositories(gi,name=None,
-                                toolshed=None,
+                                tool_shed=None,
                                 owner=None,
                                 list_tools=False,
                                 include_deleted=False,
@@ -757,7 +757,7 @@ def list_installed_repositories(gi,name=None,
       gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
       name (str): optional, only list tool repositiories
         which match this string (can include wildcards)
-      toolshed (str): optional, only list tool
+      tool_shed (str): optional, only list tool
         repositories from toolsheds that match this string
         (can include wildcards)
       owner (str): optional, only list tool repositiories
@@ -780,7 +780,7 @@ def list_installed_repositories(gi,name=None,
     """
     # Get the list of installed repos
     repos = installed_repositories(gi,name=name,
-                                   toolshed=toolshed,
+                                   tool_shed=tool_shed,
                                    owner=owner,
                                    include_deleted=include_deleted,
                                    only_updateable=only_updateable)


### PR DESCRIPTION
WIP PR to synchronise explicitly against toolsheds when checking if updates are available for installed tools via the `list_installed_tools` and `update_tool` command.

Currently checks on whether the installed tool repository versions are the most recent are done using the cached information in the Galaxy instance where the tools are installed. However this information is only updated when an administrator performs the relevant actions via the Galaxy's tool admin page.

This PR enables nebulizer to fetch information on the available tool repository revisions from the toolshed, to see if more recent versions are available, by specifying a new `--check-toolshed` option on these commands.