### PR TITLE
Add command to search toolsheds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,11 +141,6 @@ link::
 Managing Tools
 --------------
 
-Search the main Galaxy toolshed for available tools::
-
-  nebulizer search_toolshed trimmomatic
-  nebulizer search_toolshed "deseq*"
-
 List all tools that are available in a Galaxy instance::
 
   nebulizer list_tools galaxy
@@ -163,15 +158,29 @@ List all the tool repositories that have available updates or upgrades::
 
   nebulizer list_installed_tools localhost --updateable
 
-Install the most recent FastQC from the main toolshed::
+Search the main Galaxy toolshed for available tools::
+
+  nebulizer search_toolshed fastqc
+
+(see the section below for more information on the ``search_toolshed``
+command).
+
+Install the most recent FastQC from the main Galaxy toolshed, under the
+``NGS: QC and manipulation`` section of the tool panel::
+
+  nebulizer install_tool localhost devteam/fastqc \
+    --tool-panel-section="NGS: QC and manipulation"
+
+Install a specific revision of a tool from the test toolshed::
 
   nebulizer install_tool localhost \
-    --tool-panel-section="NGS: QC and manipulation" \
-    toolshed.g2.bx.psu.edu devteam fastqc
+    https://testtoolshed.g2.bx.psu.edu/view/devteam/trimmer/dec27ea206c3 \
+    --tool-panel-section="Test tools"
 
-Update FastQC tool to latest installable revision::
+Update FastQC tool by installing the latest revision, if a new version
+is available::
 
-  nebulizer update_tool localhost toolshed.g2.bx.psu.edu devteam fastqc
+  nebulizer update_tool localhost devteam/fastqc
 
 .. warning::
 
@@ -192,13 +201,20 @@ Searching for tool repositories on a Toolshed
 
 Search the main toolshed with the query ``deeptools``::
 
-    nebulizer -n search_toolshed toolshed.g2.bx.psu.edu deeptools
+    nebulizer search_toolshed toolshed.g2.bx.psu.edu deeptools
+
+The search query can include glob-style wildcards, and defaults
+to searching the main Galaxy toolshed if no toolshed is
+specified.
+
+For example::
+
+    nebulizer search_toolshed "deeptools*"
 
 Perform the same search checking which tool repositories are
 already installed on a local Galaxy instance::
 
-    nebulizer -n search_toolshed toolshed.g2.bx.psu.edu deeptools \
-      --galaxy localhost
+    nebulizer search_toolshed "deeptools*" --galaxy localhost
 
 ----------------------------------------------------
 Checking status and configuration of a Galaxy server

--- a/README.rst
+++ b/README.rst
@@ -181,6 +181,20 @@ Update FastQC tool to latest installable revision::
    option. Note however that this can impose a significant
    overhead which can make the commands much slower.
 
+---------------------------------------------
+Searching for tool repositories on a Toolshed
+---------------------------------------------
+
+Search the main toolshed with the query ``deeptools``::
+
+    nebulizer -n search_toolshed toolshed.g2.bx.psu.edu deeptools
+
+Perform the same search checking which tool repositories are
+already installed on a local Galaxy instance::
+
+    nebulizer -n search_toolshed toolshed.g2.bx.psu.edu deeptools \
+      --galaxy localhost
+
 ----------------------------------------------------
 Checking status and configuration of a Galaxy server
 ----------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,11 @@ link::
 Managing Tools
 --------------
 
+Search the main Galaxy toolshed for available tools::
+
+  nebulizer search_toolshed trimmomatic
+  nebulizer search_toolshed "deseq*"
+
 List all tools that are available in a Galaxy instance::
 
   nebulizer list_tools galaxy

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -18,6 +18,7 @@ from . import options
 from . import users
 from . import libraries
 from . import tools
+from . import search
 
 # Initialise logging
 logger = logging.getLogger(__name__)
@@ -817,6 +818,34 @@ def update_tool(context,galaxy,toolshed,owner,repository,
                                (install_repository_dependencies== 'yes'),
                                install_resolver_dependencies=
                                (install_resolver_dependencies== 'yes')))
+
+@nebulizer.command()
+@click.option('--galaxy',metavar='GALAXY',
+              help="check if tool repositories are installed in "
+              "GALAXY instance")
+@click.argument("toolshed")
+@click.argument("query_string")
+@pass_context
+def search_toolshed(context,toolshed,query_string,galaxy):
+    """
+    Search for repositories on a toolshed.
+
+    Searches for repositories on TOOLSHED using the
+    specified QUERY_STRING.
+
+    If a GALAXY instance is supplied then also check
+    whether the tool repositories are already installed.
+    """
+    # Get a Galaxy instance, if specified
+    if galaxy is not None:
+        gi = context.galaxy_instance(galaxy)
+        if gi is None:
+            logger.critical("Failed to connect to Galaxy instance")
+            sys.exit(1)
+    else:
+        gi = None
+    # Search the toolshed
+    sys.exit(search.search_toolshed(toolshed,query_string,gi=gi))
 
 @nebulizer.command()
 @click.option('-l','long_listing',is_flag=True,

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -820,22 +820,39 @@ def update_tool(context,galaxy,toolshed,owner,repository,
                                (install_resolver_dependencies== 'yes')))
 
 @nebulizer.command()
+@click.option("--toolshed",metavar='TOOLSHED',
+              help="specify a toolshed URL to search, or 'main' "
+              "(the main Galaxy toolshed, the default) or 'test' "
+              "(the test Galaxy toolshed)")
 @click.option('--galaxy',metavar='GALAXY',
               help="check if tool repositories are installed in "
               "GALAXY instance")
-@click.argument("toolshed")
+@click.option('-l','long_listing',is_flag=True,
+              help="use a long listing format that includes "
+              "tool descriptions")
 @click.argument("query_string")
 @pass_context
-def search_toolshed(context,toolshed,query_string,galaxy):
+def search_toolshed(context,toolshed,query_string,galaxy,long_listing):
     """
-    Search for repositories on a toolshed.
+    Search for repositories on a Galaxy toolshed.
 
-    Searches for repositories on TOOLSHED using the
-    specified QUERY_STRING.
+    Searches for repositories on the main Galaxy toolshed
+    using the specified QUERY_STRING.
+
+    Specify other toolsheds by an alias (either 'main' or
+    'test') or by supplying the shed URL.
 
     If a GALAXY instance is supplied then also check
     whether the tool repositories are already installed.
     """
+    # Determine the toolshed
+    if toolshed is None:
+        # Default to the main Galaxy toolshed
+        toolshed = "main"
+    if toolshed == "main":
+        toolshed = "https://toolshed.g2.bx.psu.edu/"
+    elif toolshed == "test":
+        toolshed = "https://testtoolshed.g2.bx.psu.edu/"
     # Get a Galaxy instance, if specified
     if galaxy is not None:
         gi = context.galaxy_instance(galaxy)
@@ -845,7 +862,8 @@ def search_toolshed(context,toolshed,query_string,galaxy):
     else:
         gi = None
     # Search the toolshed
-    sys.exit(search.search_toolshed(toolshed,query_string,gi=gi))
+    sys.exit(search.search_toolshed(toolshed,query_string,gi=gi,
+                                    long_listing_format=long_listing))
 
 @nebulizer.command()
 @click.option('-l','long_listing',is_flag=True,

--- a/nebulizer/search.py
+++ b/nebulizer/search.py
@@ -3,9 +3,9 @@
 # search: functions for searching toolshed
 import logging
 import string
-from core import get_galaxy_instance
-from tools import normalise_toolshed_url
-from tools import get_repositories
+from .core import get_galaxy_instance
+from .tools import normalise_toolshed_url
+from .tools import get_repositories
 from bioblend import toolshed
 from bioblend import ConnectionError as BioblendConnectionError
 
@@ -45,7 +45,7 @@ def search_toolshed(tool_shed,query_string,gi=None):
     # Deal with the results
     nhits = int(search_result['total_results'])
     if nhits == 0:
-        print "No repositories found"
+        print("No repositories found")
         return 0
     # Sort results on name
     hits = sorted(search_result['hits'],
@@ -57,9 +57,8 @@ def search_toolshed(tool_shed,query_string,gi=None):
             if tool_shed_url.startswith(proc):
                 tool_shed = tool_shed_url[len(proc):]
         # Restrict repos to this tool shed
-        installed_repos = filter(lambda r:
-                                 r.tool_shed == tool_shed,
-                                 get_repositories(gi))
+        installed_repos = [r for r in get_repositories(gi)
+                           if r.tool_shed == tool_shed]
     else:
         installed_repos = []
     # Print the results
@@ -70,20 +69,18 @@ def search_toolshed(tool_shed,query_string,gi=None):
         owner = repo['repo_owner_username']
         description = to_ascii(repo['description']).strip()
         # Look to see it's installed
-        installed = bool(filter(lambda r:
-                                r.name == name and
-                                r.owner == owner,
-                                installed_repos))
+        installed = bool([r for r in installed_repos
+                          if (r.name == name and r.owner == owner)])
         if installed:
             status = "*"
         else:
             status = " "
         # Print details
-        print "% 3d %s" % (i+1,
+        print("% 3d %s" % (i+1,
                            '\t'.join(["%s %s" % (status,name),
                                       owner,
-                                      description]))
-    print "%d repositor%s found" % (nhits,('y' if nhits == 1 else 'ies'))
+                                      description])))
+    print("%d repositor%s found" % (nhits,('y' if nhits == 1 else 'ies')))
     # Finished
     return 0
 

--- a/nebulizer/search.py
+++ b/nebulizer/search.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+#
+# search: functions for searching toolshed
+import logging
+import string
+from bioblend import toolshed
+from core import get_galaxy_instance
+from tools import normalise_toolshed_url
+from tools import get_repositories
+
+# Logging
+logger = logging.getLogger(__name__)
+
+# Constants
+SEARCH_PAGE_SIZE = 1000
+
+# Functions
+
+def search_toolshed(tool_shed,query_string,gi=None):
+    """
+    Search toolshed and print resulting matches
+
+    Arguments:
+      tool_shed (str): URL for tool shed to search
+      query_string (str): text to use as query
+      gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
+      name (str): optional, only list tools which match this
+        string (can include wildcards)
+    """
+    # Get a toolshed instance
+    tool_shed_url = normalise_toolshed_url(tool_shed)
+    shed = toolshed.ToolShedInstance(tool_shed_url)
+    # Query the toolshed
+    repo_client = toolshed.repositories.ToolShedRepositoryClient(shed)
+    search_result = repo_client.search_repositories(
+        query_string,
+        page_size=SEARCH_PAGE_SIZE)
+    # Deal with the results
+    nhits = int(search_result['total_results'])
+    if nhits == 0:
+        print "No repositories found"
+        return 0
+    # Sort results on name
+    hits = sorted(search_result['hits'],
+                  key=lambda r: r['repository']['name'])
+    # Get list of installed tool repositories
+    if gi is not None:
+        # Strip protocol from tool shed URL
+        for proc in ('http://','https://'):
+            if tool_shed_url.startswith(proc):
+                tool_shed = tool_shed_url[len(proc):]
+        # Restrict repos to this tool shed
+        installed_repos = filter(lambda r:
+                                 r.tool_shed == tool_shed,
+                                 get_repositories(gi))
+    else:
+        installed_repos = []
+    # Print the results
+    for i,hit in enumerate(hits):
+        # Get the repository details
+        repo = hit['repository']
+        name = repo['name']
+        owner = repo['repo_owner_username']
+        description = to_ascii(repo['description']).strip()
+        # Look to see it's installed
+        installed = bool(filter(lambda r:
+                                r.name == name and
+                                r.owner == owner,
+                                installed_repos))
+        if installed:
+            status = "*"
+        else:
+            status = " "
+        # Print details
+        print "% 3d %s" % (i+1,
+                           '\t'.join(["%s %s" % (status,name),
+                                      owner,
+                                      description]))
+    print "%d repositor%s found" % (nhits,('y' if nhits == 1 else 'ies'))
+    # Finished
+    return 0
+
+def to_ascii(s,replace_with='?'):
+    """
+    Convert a string to ASCII
+
+    Converts the supplied string to ASCII by replacing
+    any non-ASCII characters with the specified
+    character (defaults to '?').
+    """
+    try:
+        return str(s)
+    except UnicodeEncodeError:
+        s1 = []
+        for c in s:
+            if c in string.printable:
+                s1.append(c)
+            else:
+                s1.append(replace_with)
+        return ''.join(s1)


### PR DESCRIPTION
PR implements a `search_toolshed` command, to enable searching for repositories on toolsheds via the command line.

For example:

     nebulizer search_toolshed deeptools

Adds a `--galaxy` option to check whether matched repositories are also installed in the specified Galaxy instance.