### PR TITLE
Expose options to handle tool dependencies on tool install

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -740,6 +740,9 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
     sys.exit(0)
 
 @nebulizer.command()
+@options.install_tool_dependencies_option(default='yes')
+@options.install_repository_dependencies_option(default='yes')
+@options.install_resolver_dependencies_option(default='yes')
 @click.option('--timeout',metavar='TIMEOUT',default=600,
               help="wait up to TIMEOUT seconds for tool installations"
               "to complete (default is 600).")
@@ -755,6 +758,9 @@ def install_repositories(context,galaxy,file,timeout,no_wait):
 @click.argument("repository")
 @pass_context
 def update_tool(context,galaxy,toolshed,owner,repository,
+                install_tool_dependencies,
+                install_repository_dependencies,
+                install_resolver_dependencies,
                 timeout,no_wait,check_toolshed):
     """
     Update tool installed from toolshed.
@@ -775,7 +781,13 @@ def update_tool(context,galaxy,toolshed,owner,repository,
     # Install tool
     sys.exit(tools.update_tool(gi,toolshed,repository,owner,
                                timeout=timeout,no_wait=no_wait,
-                               check_tool_shed=check_toolshed))
+                               check_tool_shed=check_toolshed,
+                               install_tool_dependencies=
+                               (install_tool_dependencies == 'yes'),
+                               install_repository_dependencies=
+                               (install_repository_dependencies== 'yes'),
+                               install_resolver_dependencies=
+                               (install_resolver_dependencies== 'yes')))
 
 @nebulizer.command()
 @click.option('-l','long_listing',is_flag=True,

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -12,6 +12,7 @@ from .core import get_current_user
 from .core import ping_galaxy_instance
 from .core import turn_off_urllib3_warnings
 from .core import Credentials
+import options
 import users
 import libraries
 import tools
@@ -564,6 +565,9 @@ def list_tool_panel(context,galaxy,name,list_tools):
               "then it will be created. If this option is "
               "omitted then the tool will be installed at the "
               "top-level i.e. not in any section.")
+@options.install_tool_dependencies_option(default='yes')
+@options.install_repository_dependencies_option(default='yes')
+@options.install_resolver_dependencies_option(default='yes')
 @click.option('--timeout',metavar='TIMEOUT',default=600,
               help="wait up to TIMEOUT seconds for tool installations"
               "to complete (default is 600).")
@@ -577,7 +581,11 @@ def list_tool_panel(context,galaxy,name,list_tools):
 @click.argument("revision",required=False)
 @pass_context
 def install_tool(context,galaxy,toolshed,owner,repository,
-                 revision,tool_panel_section,timeout,no_wait):
+                 revision,tool_panel_section,
+                 install_tool_dependencies,
+                 install_repository_dependencies,
+                 install_resolver_dependencies,
+                 timeout,no_wait):
     """
     Install tool from toolshed.
 
@@ -601,7 +609,13 @@ def install_tool(context,galaxy,toolshed,owner,repository,
     sys.exit(tools.install_tool(
         gi,toolshed,repository,owner,revision=revision,
         tool_panel_section=tool_panel_section,
-        timeout=timeout,no_wait=no_wait))
+        timeout=timeout,no_wait=no_wait,
+        install_tool_dependencies=
+        (install_tool_dependencies == 'yes'),
+        install_repository_dependencies=
+        (install_repository_dependencies== 'yes'),
+        install_resolver_dependencies=
+        (install_resolver_dependencies== 'yes')))
 
 @nebulizer.command()
 @click.option('--name',metavar='NAME',

--- a/nebulizer/options.py
+++ b/nebulizer/options.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#
+# options: click definitions for shared options and arguments
+import click
+
+def install_tool_dependencies_option(default='yes'):
+    return click.option('--install-tool-dependencies',
+                        default=default,
+                        type=click.Choice(['yes','no']),
+                        help="install tool dependencies via the "
+                        "toolshed, if any are defined (default "
+                        "is '%s')" % default)
+
+def install_repository_dependencies_option(default='yes'):
+    return click.option('--install-repository-dependencies',
+                        default=default,
+                        type=click.Choice(['yes','no']),
+                        help="install repository dependencies "
+                        "via the toolshed, if any are defined "
+                        "(default is '%s')" % default)
+
+def install_resolver_dependencies_option(default='yes'):
+    return click.option('--install-resolver-dependencies',
+                        default=default,
+                        type=click.Choice(['yes','no']),
+                        help="install dependencies through a "
+                        "resolver that supports installation "
+                        "(e.g. conda) (default is '%s')" %
+                        default)

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -959,7 +959,11 @@ def list_tool_panel(gi,name=None,list_tools=False):
     print "total %s" % len(sections)
 
 def install_tool(gi,tool_shed,name,owner,revision=None,
-                 tool_panel_section=None,timeout=600,
+                 tool_panel_section=None,
+                 install_tool_dependencies=True,
+                 install_repository_dependencies=True,
+                 install_resolver_dependencies=True,
+                 timeout=600,
                  poll_interval=30,no_wait=False):
     """
     Install a tool repository into a Galaxy instance
@@ -980,6 +984,15 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
         the tool panel section to install the tools under; if
         the tool panel section doesn't already exist it will
         be created.
+      install_tool_dependencies (bool): optional, if True
+        then install tool dependencies from the toolshed
+        if possible (default).
+      install_repository_dependencies (bool): optional, if
+        True then install repository dependencies from the
+        toolshed if possible (default).
+      install_resolver_dependencies (bool): optional, if
+        True then install dependencies using a resolver
+        which supports this (e.g. conda) (default).
       timeout (int): optional, sets the maximum time (in
         seconds) to wait for a tool to complete installing
         before giving up (default is 600s). Ignored if
@@ -1004,6 +1017,16 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
         print "Revision  :\t%s" % revision
     else:
         print "Revision  :\t<not specified>"
+    # Information on dependency installation
+    print "Install tool dependencies from toolshed      : " \
+        "%s" % ('yes' if install_tool_dependencies
+                else 'no')
+    print "Install repository dependencies from toolshed: " \
+        "%s" % ('yes' if install_repository_dependencies
+                else 'no')
+    print "Install dependencies using resolver          : " \
+        "%s" % ('yes' if install_resolver_dependencies
+                else 'no')
     # Check if tool is already installed
     install_status = tool_install_status(gi,tool_shed,owner,name,
                                          revision)
@@ -1064,9 +1087,9 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
         tool_shed_client = galaxy.toolshed.ToolShedClient(gi)
         tool_shed_client.install_repository_revision(
             tool_shed_url,name,owner,revision,
-            install_tool_dependencies=True,
-            install_repository_dependencies=True,
-            install_resolver_dependencies=True,
+            install_tool_dependencies=install_tool_dependencies,
+            install_repository_dependencies=install_repository_dependencies,
+            install_resolver_dependencies=install_resolver_dependencies,
             tool_panel_section_id=tool_panel_section_id,
             new_tool_panel_section_label=new_tool_panel_section)
     except ConnectionError as connection_error:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1066,6 +1066,7 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
             tool_shed_url,name,owner,revision,
             install_tool_dependencies=True,
             install_repository_dependencies=True,
+            install_resolver_dependencies=True,
             tool_panel_section_id=tool_panel_section_id,
             new_tool_panel_section_label=new_tool_panel_section)
     except ConnectionError as connection_error:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1127,7 +1127,11 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
     logger.critical("%s: timed out waiting for install" % name)
     return TOOL_INSTALL_TIMEOUT
 
-def update_tool(gi,tool_shed,name,owner,timeout=600,poll_interval=30,
+def update_tool(gi,tool_shed,name,owner,
+                install_tool_dependencies=True,
+                install_repository_dependencies=True,
+                install_resolver_dependencies=True,
+                timeout=600,poll_interval=30,
                 no_wait=False,check_tool_shed=False):
     """
     Update a tool repository in a Galaxy instance
@@ -1138,6 +1142,15 @@ def update_tool(gi,tool_shed,name,owner,timeout=600,poll_interval=30,
         tool from
       name (str): name of the tool repository
       owner (str): name of the tool repository owner
+      install_tool_dependencies (bool): optional, if True
+        then install tool dependencies from the toolshed
+        if possible (default).
+      install_repository_dependencies (bool): optional, if
+        True then install repository dependencies from the
+        toolshed if possible (default).
+      install_resolver_dependencies (bool): optional, if
+        True then install dependencies using a resolver
+        which supports this (e.g. conda) (default).
       timeout (int): optional, sets the maximum time (in
         seconds) to wait for a tool to complete installing
         before giving up (default is 600s). Ignored if
@@ -1193,7 +1206,11 @@ def update_tool(gi,tool_shed,name,owner,timeout=600,poll_interval=30,
     if tool_panel_section is None:
         logger.warning("%s: no tool panel section found" % name)
     #print "Installing update under %s" % tool_panel_section
-    return install_tool(gi,tool_shed,name,owner,revision,
-                        tool_panel_section=tool_panel_section,
-                        timeout=timeout,poll_interval=poll_interval,
-                        no_wait=no_wait)
+    return install_tool(
+        gi,tool_shed,name,owner,revision,
+        install_tool_dependencies=install_tool_dependencies,
+        install_repository_dependencies=install_repository_dependencies,
+        install_resolver_dependencies=install_resolver_dependencies,
+        tool_panel_section=tool_panel_section,
+        timeout=timeout,poll_interval=poll_interval,
+        no_wait=no_wait)


### PR DESCRIPTION
WIP to expose the bioblend options for handling tool dependency installation when tools are installed (see issue #17).

Also addresses bug in issue #43.