### PR TITLE
Explicitly specify version of 'click' library to avoid version 7.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license = 'AFL',
     install_requires = ['bioblend',
                         'mako',
-                        'click'],
+                        'click<=6.7'],
     test_suite = 'nose.collector',
     tests_require = ['nose'],
     platforms="Posix; MacOS X; Windows",


### PR DESCRIPTION
PR which addresses issue #48, by specifying a the version of the `click` package to be less than version 7.x. This should ensure that subcommands have underscores rather than dashes i.e. `list_users` not
`list-users`.