### PR TITLE
Fix formatting error in CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ v0.5.0 (2020-04-20)
    (`PR #50 <https://github.com/pjbriggs/nebulizer/pull/50>`_,
    `PR #51 <https://github.com/pjbriggs/nebulizer/pull/51>`_)
 
- -------------------
+-------------------
 v0.4.3 (2018-10-05)
 -------------------
 


### PR DESCRIPTION
PR to fix a formatting error in `CHANGELOG.rst` which messes up Sphinx documentation when published on ReadTheDocs.