### PR TITLE
Add new 'config' command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,14 +181,19 @@ Update FastQC tool to latest installable revision::
    option. Note however that this can impose a significant
    overhead which can make the commands much slower.
 
-----------------------------------
-Checking status of a Galaxy server
-----------------------------------
+----------------------------------------------------
+Checking status and configuration of a Galaxy server
+----------------------------------------------------
 
 'Ping' a Galaxy instance to check it's alive and responding to
 requests::
 
     nebulizer ping localhost
+
+Get information about an instance's configuration using
+
+::
+   nebulizer config localhost
 
 Commands
 --------

--- a/README.rst
+++ b/README.rst
@@ -250,6 +250,7 @@ Other commands
 
  * ``ping``: 'Ping' a Galaxy instance.
  * ``whoami``: Print user details associated with API key.
+ * ``config``: Report configuration for a Galaxy instance.
 
 Hints and Tips
 --------------

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -945,11 +945,13 @@ def config(context,galaxy,name=None):
     Reports the available configuration information from
     GALAXY. Use --name to filter which items are reported.
     """
-    try:
-        galaxy_url,_ = Credentials().fetch_key(galaxy)
-    except KeyError:
-        galaxy_url = galaxy
-    config = get_galaxy_config(context.galaxy_instance(galaxy_url))
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # Fetch and report configuration
+    config = get_galaxy_config(gi)
     items = sorted(config.keys())
     if name:
         name = name.lower()


### PR DESCRIPTION
PR which adds a new command `config`, to fetch and report configuration information from a Galaxy instance, e.g.

    nebulizer config https://usegalaxy.org

will report the configuration as key:value pairs:

    ...
    allow_user_creation: True
    allow_user_dataset_purge: True
    allow_user_impersonation: False
    ...

A `--name` option filters the reported keys (e.g. `--name "allow*"`).