### PR TITLE
Implement flexible repo specification for tool install and update

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -591,13 +591,9 @@ def list_tool_panel(context,galaxy,name,list_tools):
               help="don't wait for lengthy tool installations to "
               "complete.")
 @click.argument("galaxy")
-@click.argument("toolshed")
-@click.argument("owner")
-@click.argument("repository")
-@click.argument("revision",required=False)
+@click.argument("repository",nargs=-1)
 @pass_context
-def install_tool(context,galaxy,toolshed,owner,repository,
-                 revision,tool_panel_section,
+def install_tool(context,galaxy,repository,tool_panel_section,
                  install_tool_dependencies,
                  install_repository_dependencies,
                  install_resolver_dependencies,
@@ -605,17 +601,35 @@ def install_tool(context,galaxy,toolshed,owner,repository,
     """
     Install tool from toolshed.
 
-    Installs the specified tool from REPOSITORY owned by
-    OWNER in TOOLSHED, into GALAXY.
+    Installs the specified tool from REPOSITORY into GALAXY,
+    where REPOSITORY can be as one of:
 
-    Optionally also specify a changeset REVISION; if no
-    revision is specified and no version of the tool is
-    already installed then will attempt to install the
-    latest revision (otherwise will skip installation).
+    - full URL including the revision e.g.
+    https://toolshed.g2.bx.psu.edu/view/devteam/fastqc/e7b2202befea
+
+    - full URL without revision e.g.
+    https://toolshed.g2.bx.psu.edu/view/devteam/fastqc
+
+    - OWNER/TOOLNAME combination e.g. devteam/fastqc
+    (toolshed is assumed to be main Galaxy toolshed)
+
+    - [ TOOLSHED ] OWNER TOOLNAME [ REVISION ] e.g.
+    https://toolshed.g2.bx.psu.edu devteam fastqc
+
+    If a changeset REVISION isn't specified then the
+    latest revision will be assumed.
+
     Installation will fail if the specified revision is
     not installable, or if no installable revisions are
     found.
     """
+    # Get the tool repository details
+    toolshed,owner,repository,revision = \
+        tools.handle_repository_spec(repository)
+    click.echo("Toolshed   %s" % toolshed)
+    click.echo("Owner      %s" % owner)
+    click.echo("Repository %s" % repository)
+    click.echo("Revision   %s" % revision)
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:
@@ -782,11 +796,9 @@ def install_repositories(context,galaxy,file,
               help="check installed revisions directly against those "
               "available in the toolshed")
 @click.argument("galaxy")
-@click.argument("toolshed")
-@click.argument("owner")
-@click.argument("repository")
+@click.argument("repository",nargs=-1)
 @pass_context
-def update_tool(context,galaxy,toolshed,owner,repository,
+def update_tool(context,galaxy,repository,
                 install_tool_dependencies,
                 install_repository_dependencies,
                 install_resolver_dependencies,
@@ -794,14 +806,32 @@ def update_tool(context,galaxy,toolshed,owner,repository,
     """
     Update tool installed from toolshed.
 
-    Updates the specified tool from REPOSITORY owned by
-    OWNER in TOOLSHED, to the latest revision in GALAXY.
+    Updates the specified tool from REPOSITORY into GALAXY,
+    where REPOSITORY can be as one of:
+
+    - full URL including the revision e.g.
+    https://toolshed.g2.bx.psu.edu/view/devteam/fastqc/e7b2202befea
+
+    - full URL without revision e.g.
+    https://toolshed.g2.bx.psu.edu/view/devteam/fastqc
+
+    - OWNER/TOOLNAME combination e.g. devteam/fastqc
+    (toolshed is assumed to be main Galaxy toolshed)
+
+    - [ TOOLSHED ] OWNER TOOLNAME [ REVISION ] e.g.
+    https://toolshed.g2.bx.psu.edu devteam fastqc
+
+    If a changeset REVISION isn't specified then the
+    latest revision will be assumed.
 
     The tool must already be present in GALAXY and a newer
     changeset revision must be available. The update will
     be installed into the same tool panel section as the
     original tool.
     """
+    # Get the tool repository details
+    toolshed,owner,repository,revision = \
+        tools.handle_repository_spec(repository)
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -809,20 +809,14 @@ def update_tool(context,galaxy,repository,
     Updates the specified tool from REPOSITORY into GALAXY,
     where REPOSITORY can be as one of:
 
-    - full URL including the revision e.g.
-    https://toolshed.g2.bx.psu.edu/view/devteam/fastqc/e7b2202befea
-
-    - full URL without revision e.g.
+    - full URL (without revision) e.g.
     https://toolshed.g2.bx.psu.edu/view/devteam/fastqc
 
     - OWNER/TOOLNAME combination e.g. devteam/fastqc
     (toolshed is assumed to be main Galaxy toolshed)
 
-    - [ TOOLSHED ] OWNER TOOLNAME [ REVISION ] e.g.
+    - [ TOOLSHED ] OWNER TOOLNAME e.g.
     https://toolshed.g2.bx.psu.edu devteam fastqc
-
-    If a changeset REVISION isn't specified then the
-    latest revision will be assumed.
 
     The tool must already be present in GALAXY and a newer
     changeset revision must be available. The update will
@@ -832,6 +826,12 @@ def update_tool(context,galaxy,repository,
     # Get the tool repository details
     toolshed,owner,repository,revision = \
         tools.handle_repository_spec(repository)
+    print("Updating %s/%s from %s" % (repository,owner,toolshed))
+    if revision is not None:
+        logger.fatal("A revision ('%s') was also supplied "
+                     "but this is not valid for tool update "
+                     % revision)
+        sys.exit(1)
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -676,7 +676,6 @@ def handle_repository_spec(repo_spec):
             repo0 = "https://toolshed.g2.bx.psu.edu/view/" + repo0
     repository[0] = repo0
     tool_url = '/'.join(repository)
-    print(tool_url)
     # Decompose the URL into toolshed, owner, repository
     # and changeset components
     toolshed = list()

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1164,12 +1164,17 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
             tool_panel_section_id=tool_panel_section_id,
             new_tool_panel_section_label=new_tool_panel_section)
     except ConnectionError as connection_error:
-        # Handle error
+        # Handle API error
         logger.warning("Got error from Galaxy API on attempted install "
                        "(ignored)")
         logger.warning("Status code: %s" % connection_error.status_code)
         logger.warning("Message    : \"%s\"" %
                        json.loads(connection_error.body)["err_msg"])
+    except Exception as ex:
+        # Handle general error
+        logger.warning("Error while requesting tool installation "
+                       "(ignored)")
+        logger.warning("Exception: %s" % ex)
     # Check installation status
     ntries = 0
     while (ntries*poll_interval) < timeout:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1255,12 +1255,9 @@ def update_tool(gi,tool_shed,name,owner,
             update_repo = repo
             break
     if update_repo is None:
-        logger.critical("%s: unable to find repository for update" %
+        logger.critical("%s: unable to find repository to update" %
                         name)
         return TOOL_UPDATE_FAIL
-    print("Toolshed:\t%s" % tool_shed)
-    print("Repository:\t%s" % name)
-    print("Owner:\t%s" % owner)
     # Update the toolshed status
     if check_tool_shed:
         repo.update_tool_shed_revision_status()

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -4,6 +4,7 @@ import unittest
 from nebulizer.tools import Tool
 from nebulizer.tools import Repository
 from nebulizer.tools import ToolPanelSection
+from nebulizer.tools import handle_repository_spec
 from nebulizer.tools import normalise_toolshed_url
 
 class TestTool(unittest.TestCase):
@@ -329,6 +330,77 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertFalse(section.is_tool)
         self.assertTrue(section.is_label)
         self.assertEqual(len(section.elems),0)
+
+class TestHandleRepositorySpec(unittest.TestCase):
+    """
+    Tests for the 'handle_repository_spec' function
+    """
+    def test_handle_repository_spec_full_url(self):
+        self.assertEqual(
+            handle_repository_spec(("https://toolshed.g2.bx.psu.edu/view/devteam/fastqc/e7b2202befea",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             "e7b2202befea"
+            ))
+        self.assertEqual(
+            handle_repository_spec(("https://toolshed.g2.bx.psu.edu/view/devteam/fastqc",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             None
+            ))
+    def test_handle_repository_spec_full_url(self):
+        self.assertEqual(
+            handle_repository_spec(("https://local.org/toolshed/view/devteam/fastqc/e7b2202befea",)),
+            ("local.org/toolshed",
+             "devteam",
+             "fastqc",
+             "e7b2202befea"
+            ))
+    def test_handle_repository_spec_owner_slash_tool(self):
+        self.assertEqual(
+            handle_repository_spec(("devteam/fastqc",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             None
+            ))
+    def test_handle_repository_spec_owner_space_tool(self):
+        self.assertEqual(
+            handle_repository_spec(("devteam","fastqc",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             None
+            ))
+    def test_handle_repository_spec_space_separated(self):
+        self.assertEqual(
+            handle_repository_spec(("toolshed.g2.bx.psu.edu",
+                                    "devteam","fastqc",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             None
+            ))
+        self.assertEqual(
+            handle_repository_spec(("toolshed.g2.bx.psu.edu",
+                                    "devteam","fastqc",
+                                    "e7b2202befea",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             "e7b2202befea"
+            ))
+        self.assertEqual(
+            handle_repository_spec(("toolshed.g2.bx.psu.edu",
+                                    "devteam","fastqc",
+                                    "3:e7b2202befea",)),
+            ("toolshed.g2.bx.psu.edu",
+             "devteam",
+             "fastqc",
+             "e7b2202befea"
+            ))
 
 class TestNormaliseToolshedUrl(unittest.TestCase):
     """


### PR DESCRIPTION
PR that implements a more flexible way of specifying the tool repository when using the `install_tool` and `update_tool` commands, so that it's possible to specify:

* Full toolshed URL (with or without revision) e.g. `https://toolshed.g2.bx.psu.edu/view/devteam/fastqc/e7b2202befea` or `https://toolshed.g2.bx.psu.edu/view/devteam/fastqc`
* OWNER/TOOLNAME[/REVISION] combination e.g. `devteam/fastqc` or `devteam/fastqc/e7b2202befea` (in which case toolshed is assumed to be main Galaxy toolshed)
* [ TOOLSHED ] OWNER TOOLNAME [ REVISION ] (i.e. the old space-separated style) e.g. `https://toolshed.g2.bx.psu.edu devteam fastqc`

The idea is to facilitate cutting and pasting of repo specifications to make it easier to use the commands.