### PR TITLE
Add 'delete_user' command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,10 @@ Add a new user::
 
   nebulizer create_user galaxy -p pa55w0rd a.non@galaxy.org
 
+Delete and purge an existing user::
+
+  nebulizer delete_user galaxy a.non@galaxy.org --purge
+
 -----------------------
 Managing Data Libraries
 -----------------------
@@ -244,6 +248,7 @@ User Management
  * ``create_user``: Create new Galaxy user.
  * ``create_batch_users``: Create multiple Galaxy users from a template.
  * ``create_users_from_file``: Create multiple Galaxy users from a file.
+ * ``delete_user``: Delete a Galaxy user.
 
 -----------------------
 Data Library Management

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -461,7 +461,7 @@ def create_users_from_file(context,galaxy,file,message_template,
 @nebulizer.command()
 @click.argument("galaxy")
 @click.argument("email")
-@click.option('-p','--purge',
+@click.option('-p','--purge',is_flag=True,
               help="also purge (permanently delete) the user.")
 @click.option('-y','--yes',is_flag=True,
               help="don't ask for confirmation of deletions.")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -459,6 +459,27 @@ def create_users_from_file(context,galaxy,file,message_template,
                                          mako_template=message_template))
 
 @nebulizer.command()
+@click.argument("galaxy")
+@click.argument("email")
+@click.option('-p','--purge',
+              help="also purge (permanently delete) the user.")
+@click.option('-y','--yes',is_flag=True,
+              help="don't ask for confirmation of deletions.")
+@pass_context
+def delete_user(context,galaxy,email,purge,yes):
+    """
+    Delete a user account from a Galaxy instance
+
+    Removes user account with username EMAIL from GALAXY.
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    sys.exit(users.delete_user(gi,email,purge=purge,no_confirm=yes))
+
+@nebulizer.command()
 @click.option('--name',metavar='NAME',
               help="list only tools matching NAME. Can include "
               "glob-style wild-cards.")

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -2,6 +2,7 @@
 #
 # core: core nebulizer classes and functions
 
+import sys
 import os
 import re
 import fnmatch
@@ -272,6 +273,50 @@ def ping_galaxy_instance(gi):
         retcode = ex.status_code
     end = time.time()
     return (retcode,end-start)
+
+def prompt_for_confirmation(question,default=None):
+    """
+    Prompt the user to confirm an action
+
+    Arguments:
+      question: text to display next to the prompt
+      default: default to use if user doesn't supply
+        an explicit response (one of 'y','yes','n'
+        or 'no')
+
+    Returns:
+      True if user confirms, False if not.
+
+    """
+    responses = {
+        'yes': True,
+        'ye' : True,
+        'y'  : True,
+        'no' : False,
+        'n'  : False,
+    }
+    if default is None:
+        prompt = " [y/n] "
+    elif default.lower().startswith('y'):
+        prompt = " [Y/n] "
+    elif default.lower().startswith('n'):
+        prompt = " [y/N] "
+    else:
+        raise Exception("Invalid default for prompt: %s" %
+                        default)
+    while True:
+        sys.stdout.write(question + prompt)
+        try:
+            choice = input().lower()
+        except NameError:
+            choice = raw_input().lower()
+        if default is not None and choice == '':
+            return responses[default.lower()]
+        elif choice in responses:
+            return responses[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' "
+                             "(or 'y' or 'n').\n")
 
 def turn_off_urllib3_warnings():
     """

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -397,8 +397,8 @@ def delete_user(gi,email,purge=False,no_confirm=False):
         return 1
     # Prompt user for confirmation
     if no_confirm or prompt_for_confirmation(
-            "Delete user %s'%s'?" % (email,
-                                     " & purge" if purge else ''),
+            "Delete %suser '%s'?" % (" & purge" if purge else '',
+                                     email),
             default="n"):
         try:
             galaxy.users.UserClient(gi).delete_user(user_id,purge=purge)

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -562,7 +562,10 @@ def prompt_for_confirmation(question,default=None):
                         default)
     while True:
         sys.stdout.write(question + prompt)
-        choice = input().lower()
+        try:
+            choice = input().lower()
+        except NameError:
+            choice = raw_input().lower()
         if default is not None and choice == '':
             return responses[default.lower()]
         elif choice in responses:

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -2,7 +2,6 @@
 #
 # users: functions for managing users
 import logging
-import sys
 import re
 import getpass
 import fnmatch
@@ -10,6 +9,7 @@ from bioblend import galaxy
 from bioblend import ConnectionError
 from mako.template import Template
 from .core import get_galaxy_config
+from .core import prompt_for_confirmation
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -529,47 +529,3 @@ def render_mako_template(filename,email,password=None):
     return Template(filename=filename).render(first_name=first_name,
                                               email=email,
                                               password=password)
-
-def prompt_for_confirmation(question,default=None):
-    """
-    Prompt the user to confirm an action
-
-    Arguments:
-      question: text to display next to the prompt
-      default: default to use if user doesn't supply
-        an explicit response (one of 'y','yes','n'
-        or 'no')
-
-    Returns:
-      True if user confirms, False if not.
-
-    """
-    responses = {
-        'yes': True,
-        'ye' : True,
-        'y'  : True,
-        'no' : False,
-        'n'  : False,
-    }
-    if default is None:
-        prompt = " [y/n] "
-    elif default.lower().startswith('y'):
-        prompt = " [Y/n] "
-    elif default.lower().startswith('n'):
-        prompt = " [y/N] "
-    else:
-        raise Exception("Invalid default for prompt: %s" %
-                        default)
-    while True:
-        sys.stdout.write(question + prompt)
-        try:
-            choice = input().lower()
-        except NameError:
-            choice = raw_input().lower()
-        if default is not None and choice == '':
-            return responses[default.lower()]
-        elif choice in responses:
-            return responses[choice]
-        else:
-            sys.stdout.write("Please respond with 'yes' or 'no' "
-                             "(or 'y' or 'n').\n")


### PR DESCRIPTION
PR which implements a new `delete_user` command, which can be used to delete a user account in a Galaxy instance (provided that the instance is configured to allow admins to perform deletion operations).