### PR TITLE
Update handling of connection failure in 'ping' command

### DIFF
--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -193,8 +193,8 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
     try:
         galaxy_url,stored_key = Credentials().fetch_key(galaxy_url)
     except KeyError as ex:
-        logger.warning("Failed to find credentials for %s" %
-                       galaxy_url)
+        logger.debug("Failed to find credentials for %s" %
+                     galaxy_url)
         stored_key = None
     if api_key is None:
         api_key = stored_key


### PR DESCRIPTION
PR that updates how the `ping` command handles connection failures:

* No longer exits on failure to connect to Galaxy instance (just reports failure)
* New `--timeout` option to exit for persistent failure to connect (or if connection is lost again)

Also suppresses the warning when there are no stored credentials for the Galaxy instance.