### PR TITLE
Improvements for tool install and update commands

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -652,10 +652,6 @@ def install_tool(context,galaxy,repository,tool_panel_section,
     except Exception as ex:
         logger.fatal(ex)
         sys.exit(1)
-    click.echo("Toolshed   %s" % toolshed)
-    click.echo("Owner      %s" % owner)
-    click.echo("Repository %s" % repository)
-    click.echo("Revision   %s" % revision)
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
     if gi is None:

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -646,8 +646,12 @@ def install_tool(context,galaxy,repository,tool_panel_section,
     found.
     """
     # Get the tool repository details
-    toolshed,owner,repository,revision = \
-        tools.handle_repository_spec(repository)
+    try:
+        toolshed,owner,repository,revision = \
+            tools.handle_repository_spec(repository)
+    except Exception as ex:
+        logger.fatal(ex)
+        sys.exit(1)
     click.echo("Toolshed   %s" % toolshed)
     click.echo("Owner      %s" % owner)
     click.echo("Repository %s" % repository)
@@ -846,8 +850,12 @@ def update_tool(context,galaxy,repository,
     original tool.
     """
     # Get the tool repository details
-    toolshed,owner,repository,revision = \
-        tools.handle_repository_spec(repository)
+    try:
+        toolshed,owner,repository,revision = \
+            tools.handle_repository_spec(repository)
+    except Exception as ex:
+        logger.fatal(ex)
+        sys.exit(1)
     print("Updating %s/%s from %s" % (repository,owner,toolshed))
     if revision is not None:
         logger.fatal("A revision ('%s') was also supplied "

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1275,14 +1275,14 @@ def update_tool(gi,tool_shed,name,owner,
         return TOOL_UPDATE_FAIL
     # Update the toolshed status
     if check_tool_shed:
-        repo.update_tool_shed_revision_status()
+        update_repo.update_tool_shed_revision_status()
     # Find latest installable revision
-    if not repo.tool_shed_revisions():
+    if not update_repo.tool_shed_revisions():
         logger.critical("%s: no installable revisions found" % name)
         return TOOL_UPDATE_FAIL
-    revision = repo.tool_shed_revisions()[-1]
+    revision = update_repo.tool_shed_revisions()[-1]
     # Check that there is an update available
-    for r in repo.revisions():
+    for r in update_repo.revisions():
         if not r.deleted and (r.latest_revision and
                               not r.tool_shed_has_newer_revision()):
             print("%s: version %s already the latest version" %


### PR DESCRIPTION
PR which adds some improvements to the `install_tool` and `update_tool` commands:

* Trap for invalid repository specifications supplied on the command line (for example, repository name but no owner)
* Fix internals of `update_tool` for acquiring the information on the tool being updated
* Remove duplicated reporting of repository information to stdout for `install_tool`