### PR TITLE
WIP implement quota management commands

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Contents:
    users
    libraries
    tools
+   quotas
    querying_galaxy
    managing_keys
    general_options

--- a/docs/quotas.rst
+++ b/docs/quotas.rst
@@ -38,6 +38,14 @@ specified then ``=`` is assumed.
 * ``--default_for``: set the quota as the the default for either
   'registered' or 'unregistered' users.
 
+Users and groups can be associated with the new quota using the
+``-u`` and ``-g`` options:
+
+* ``-u``/``--users``: associate one or more users with the
+  quota, as a comma-separated list of email addresses.
+* ``-g``/``--groups``: associate one or more groups with the
+  quota, as a comma-separated list of group names.
+
 ``quotadel`` deletes an existing quota:
 
 ::

--- a/docs/quotas.rst
+++ b/docs/quotas.rst
@@ -1,0 +1,82 @@
+===============
+Managing Quotas
+===============
+
+Querying quotas
+---------------
+
+``quotas`` lists the quotas defined in a Galaxy instance:
+
+::
+
+   nebulizer quotas GALAXY
+
+* ``-l``: returns extended information for each quota, including
+  the associated users and groups.
+* ``--status``: filter list on quota status, which can be one of
+  ``active`` (the default), ``deleted`` (only list deleted
+  quotas) or ``all`` (list all active and deleted quotas).
+* ``--name``: filter list on quota name (can include glob-style
+  wildcards e.g. ``--name="*NGS*"``).
+
+Creating and deleting quotas
+----------------------------
+
+``quotaadd`` defines a new quota:
+
+::
+
+   nebulizer quotaadd GALAXY QUOTA_NAME SIZE
+
+``SIZE`` can either be an amount (e.g. ``10GB``, ``0.2 T``) or
+an amount preceeded by an operation (one of ``+``, ``-`` or
+``=``, e.g. ``=300gb``, ``+100G``). If an operation isn't
+specified then ``=`` is assumed.
+
+* ``-d``/``--description``: set the description for the quota
+  (defaults to the quota name).
+* ``--default_for``: set the quota as the the default for either
+  'registered' or 'unregistered' users.
+
+``quotadel`` deletes an existing quota:
+
+::
+
+   nebulizer quotadel GALAXY QUOTA_NAME
+
+.. note::
+
+   A deleted quota can be restored using the ``--undelete``
+   option of the ``quotamod`` command.
+
+Modifying quota definitions
+---------------------------
+
+``quotamod`` updates a quota definition:
+
+::
+
+   nebulizer quotamod GALAXY QUOTA_NAME ...
+
+Options allow various quota properties to be modified:
+
+* ``-n``/``--name``: sets a new name for the quota.
+* ``-d``/``--description``: sets a new description.
+* ``-q``/``--quota-size``: updates the size of the quota, and how
+  it is applied.
+* ``--default_for``: set the quota as the the default for either
+  'registered' or 'unregistered' users.
+
+Users and groups can be associated with the following options:
+
+* ``-a``/``--add-users``: associate one or more users with the
+  quota, as a comma-separated list of email addresses.
+* ``-r``/``--remove-users``: disassociate one or more users from
+  the quota, as a comma-separated list of email addresses.
+* ``-A``/``--add-groups``: associate one or more groups with the
+  quota, as a comma-separated list of group names.
+* ``-R``/``--remove-groups``: disassociate one or more groups from
+  the quota, as a comma-separated list of group names.
+
+Previously deleted quotas can be restored using the
+``-u``/``--undelete`` option.

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1191,12 +1191,18 @@ def quotas(context,galaxy,name,status,long_listing):
 @click.option('--default_for',
               help="set the quota as the default for either "
               "'registered' or 'unregistered' users.")
+@click.option('-u','--users',metavar="EMAIL[,EMAIL...]",
+              help="list of user emails to associate with the "
+              "quota, separated by commas.")
+@click.option('-g','--groups',metavar="GROUP[,GROUP...]",
+              help="list of group names to associate with the "
+              "quota, separated by commas.")
 @click.argument("galaxy")
 @click.argument("name")
 @click.argument("quota")
 @pass_context
 def quotaadd(context,galaxy,name,quota,description=None,
-             default_for=None):
+             default_for=None,users=None,groups=None):
     """
     Create new quota.
 
@@ -1220,6 +1226,9 @@ def quotaadd(context,galaxy,name,quota,description=None,
     'registered' or 'unregistered', in which case the new
     quota will become the default for that class of user
     (overriding any default which was previously defined).
+
+    Users and groups can also be associated with the new
+    quota with the -u/--users and -g/--groups options.
     """
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
@@ -1231,10 +1240,17 @@ def quotaadd(context,galaxy,name,quota,description=None,
     # Deal with description
     if description is None:
         description = name
+    # Deal with user and groups
+    if users:
+        users = users.split(',')
+    if groups:
+        groups = groups.split(',')
     # Create new quota
     sys.exit(create_quota(gi,name,description,
                           amount,operation,
-                          default=default_for))
+                          default=default_for,
+                          users=users,
+                          groups=groups))
 
 @nebulizer.command()
 @click.option('-n','--name',metavar="NEW_NAME",

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1227,6 +1227,79 @@ def create_quota(context,galaxy,name,quota,description=None,
                                  default=default_for))
 
 @nebulizer.command()
+@click.option('-n','--name',metavar="NEW_NAME",
+              help="new name for the quota.")
+@click.option('-d','--description',metavar="NEW_DESCRIPTION",
+              help="new description for the quota.")
+@click.option('-q','--quota-size',metavar="NEW_QUOTA_SIZE",
+              help="new quota size in the form "
+              "'[OPERATION][AMOUNT]' (e.g. '=0.2T').")
+@click.option('--default_for',metavar="registered|unregistered",
+              help="set the quota as the default for either "
+              "'registered' or 'unregistered' users.")
+@click.option('-a','--add-users',metavar="EMAIL[,EMAIL...]",
+              help="list of user emails to associate with the "
+              "quota, separated by commas.")
+@click.option('-r','--remove-users',metavar="EMAIL[,EMAIL...]",
+              help="list of user emails to disassociate from "
+              "the quota, separated by commas.")
+@click.option('-A','--add-groups',metavar="GROUP[,GROUP...]",
+              help="list of group names to associate with the "
+              "quota, separated by commas.")
+@click.option('-R','--remove-groups',metavar="GROUP[,GROUP...]",
+              help="list of group names to disassociate from "
+              "the quota, separated by commas.")
+@click.argument("galaxy")
+@click.argument("quota")
+@pass_context
+def update_quota(context,galaxy,quota,name=None,description=None,
+                 quota_size=None,default_for=None,add_users=None,
+                 remove_users=None,add_groups=None,remove_groups=None):
+    """
+    Update an existing quota.
+
+    Updates the details for the existing QUOTA in GALAXY.
+
+    The command line arguments can be used to modify any of
+    the quota's attributes, to set a new name, description
+    or quota size and type.
+
+    Users and groups can also be associated with or
+    disassociated from the quota.
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # Deal with quota specification
+    if quota_size:
+        operation,amount = quotas.handle_quota_spec(quota_size)
+    else:
+        operation = None
+        amount = None
+    # Deal with user and groups
+    if add_users:
+        add_users = add_users.split(',')
+    if remove_users:
+        remove_users = remove_users.split(',')
+    if add_groups:
+        add_groups = add_groups.split(',')
+    if remove_groups:
+        remove_groups = remove_groups.split(',')
+    # Create new quota
+    sys.exit(quotas.update_quota(gi,quota,
+                                 new_name=name,
+                                 new_description=description,
+                                 new_amount=amount,
+                                 new_operation=operation,
+                                 new_default=default_for,
+                                 add_users=add_users,
+                                 remove_users=remove_users,
+                                 add_groups=add_groups,
+                                 remove_groups=remove_groups))
+
+@nebulizer.command()
 @click.argument("galaxy")
 @click.option('--name',
               help="only show configuration items that match "

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -19,9 +19,13 @@ from .core import Reporter
 from . import options
 from . import users
 from . import libraries
-from . import quotas
 from . import tools
 from . import search
+from .quotas import handle_quota_spec
+from .quotas import list_quotas
+from .quotas import create_quota
+from .quotas import update_quota
+from .quotas import delete_quota
 
 # Initialise logging
 logger = logging.getLogger(__name__)
@@ -1164,7 +1168,7 @@ def add_library_datasets(context,galaxy,dest,file,file_type,
               "of associated users and groups.")
 @click.argument("galaxy")
 @pass_context
-def list_quotas(context,galaxy,name,status,long_listing):
+def quotas(context,galaxy,name,status,long_listing):
     """
     List quotas in Galaxy instance.
 
@@ -1176,9 +1180,9 @@ def list_quotas(context,galaxy,name,status,long_listing):
         logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
     # List users
-    sys.exit(quotas.list_quotas(gi,name=name,
-                                status=status,
-                                long_listing_format=long_listing))
+    sys.exit(list_quotas(gi,name=name,
+                         status=status,
+                         long_listing_format=long_listing))
 
 @nebulizer.command()
 @click.option('-d','--description',
@@ -1191,8 +1195,8 @@ def list_quotas(context,galaxy,name,status,long_listing):
 @click.argument("name")
 @click.argument("quota")
 @pass_context
-def create_quota(context,galaxy,name,quota,description=None,
-                 default_for=None):
+def quotaadd(context,galaxy,name,quota,description=None,
+             default_for=None):
     """
     Create new quota.
 
@@ -1223,14 +1227,14 @@ def create_quota(context,galaxy,name,quota,description=None,
         logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
     # Deal with quota specification
-    operation,amount = quotas.handle_quota_spec(quota)
+    operation,amount = handle_quota_spec(quota)
     # Deal with description
     if description is None:
         description = name
     # Create new quota
-    sys.exit(quotas.create_quota(gi,name,description,
-                                 amount,operation,
-                                 default=default_for))
+    sys.exit(create_quota(gi,name,description,
+                          amount,operation,
+                          default=default_for))
 
 @nebulizer.command()
 @click.option('-n','--name',metavar="NEW_NAME",
@@ -1258,13 +1262,13 @@ def create_quota(context,galaxy,name,quota,description=None,
 @click.argument("galaxy")
 @click.argument("quota")
 @pass_context
-def update_quota(context,galaxy,quota,name=None,description=None,
-                 quota_size=None,default_for=None,add_users=None,
-                 remove_users=None,add_groups=None,remove_groups=None):
+def quotamod(context,galaxy,quota,name=None,description=None,
+             quota_size=None,default_for=None,add_users=None,
+             remove_users=None,add_groups=None,remove_groups=None):
     """
-    Update an existing quota.
+    Modify an existing quota.
 
-    Updates the details for the existing QUOTA in GALAXY.
+    Updates the definition of the existing QUOTA in GALAXY.
 
     The command line arguments can be used to modify any of
     the quota's attributes, to set a new name, description
@@ -1280,7 +1284,7 @@ def update_quota(context,galaxy,quota,name=None,description=None,
         sys.exit(1)
     # Deal with quota specification
     if quota_size:
-        operation,amount = quotas.handle_quota_spec(quota_size)
+        operation,amount = handle_quota_spec(quota_size)
     else:
         operation = None
         amount = None
@@ -1294,16 +1298,16 @@ def update_quota(context,galaxy,quota,name=None,description=None,
     if remove_groups:
         remove_groups = remove_groups.split(',')
     # Create new quota
-    sys.exit(quotas.update_quota(gi,quota,
-                                 new_name=name,
-                                 new_description=description,
-                                 new_amount=amount,
-                                 new_operation=operation,
-                                 new_default=default_for,
-                                 add_users=add_users,
-                                 remove_users=remove_users,
-                                 add_groups=add_groups,
-                                 remove_groups=remove_groups))
+    sys.exit(update_quota(gi,quota,
+                          new_name=name,
+                          new_description=description,
+                          new_amount=amount,
+                          new_operation=operation,
+                          new_default=default_for,
+                          add_users=add_users,
+                          remove_users=remove_users,
+                          add_groups=add_groups,
+                          remove_groups=remove_groups))
 
 @nebulizer.command()
 @click.argument("galaxy")
@@ -1311,7 +1315,7 @@ def update_quota(context,galaxy,quota,name=None,description=None,
 @click.option('-y','--yes',is_flag=True,
               help="don't ask for confirmation of deletions.")
 @pass_context
-def delete_quota(context,galaxy,quota,yes):
+def quotadel(context,galaxy,quota,yes):
     """
     Delete quota.
 
@@ -1323,7 +1327,7 @@ def delete_quota(context,galaxy,quota,yes):
         logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
     # Delete quota
-    sys.exit(quotas.delete_quota(gi,quota,no_confirm=yes))
+    sys.exit(delete_quota(gi,quota,no_confirm=yes))
 
 @nebulizer.command()
 @click.argument("galaxy")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1175,6 +1175,58 @@ def list_quotas(context,galaxy,name,long_listing):
                                 long_listing_format=long_listing))
 
 @nebulizer.command()
+@click.option('-d','--description',
+              help="description of the new quota (will be "
+              "the same as the NAME if not supplied).")
+@click.option('--default_for',
+              help="set the quota as the default for either "
+              "'registered' or 'unregistered' users.")
+@click.argument("galaxy")
+@click.argument("name")
+@click.argument("quota")
+@pass_context
+def create_quota(context,galaxy,name,quota,description=None,
+                 default_for=None):
+    """
+    Create new quota.
+
+    Makes a new quota called NAME in GALAXY. A quota with
+    the same name must not already exist.
+
+    QUOTA specifies the type of quota, and must be of the
+    form
+
+    [OPERATION][AMOUNT]
+
+    where OPERATION is any valid operation ('=','+','-';
+    defaults to '=' if not specified) and AMOUNT is any
+    valid amount (e.g. '10000MB', '99 gb', '0.2T',
+    'unlimited').
+
+    If DESCRIPTION is not supplied then it will be the
+    same as the NAME.
+
+    If supplied then DEFAULT_FOR must be one of
+    'registered' or 'unregistered', in which case the new
+    quota will become the default for that class of user
+    (overriding any default which was previously defined).
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # Deal with quota specification
+    operation,amount = quotas.handle_quota_spec(quota)
+    # Deal with description
+    if description is None:
+        description = name
+    # Create new quota
+    sys.exit(quotas.create_quota(gi,name,description,
+                                 amount,operation,
+                                 default=default_for))
+
+@nebulizer.command()
 @click.argument("galaxy")
 @click.option('--name',
               help="only show configuration items that match "

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1301,6 +1301,26 @@ def update_quota(context,galaxy,quota,name=None,description=None,
 
 @nebulizer.command()
 @click.argument("galaxy")
+@click.argument("quota")
+@click.option('-y','--yes',is_flag=True,
+              help="don't ask for confirmation of deletions.")
+@pass_context
+def delete_quota(context,galaxy,quota,yes):
+    """
+    Delete quota.
+
+    Deletes QUOTA from GALAXY.
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # Delete quota
+    sys.exit(quotas.delete_quota(gi,quota,no_confirm=yes))
+
+@nebulizer.command()
+@click.argument("galaxy")
 @click.option('--name',
               help="only show configuration items that match "
               "NAME. Can include glob-style wild-cards.")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -19,6 +19,7 @@ from .core import Reporter
 from . import options
 from . import users
 from . import libraries
+from . import quotas
 from . import tools
 from . import search
 
@@ -1148,6 +1149,30 @@ def add_library_datasets(context,galaxy,dest,file,file_type,
                                    link_only=link,
                                    file_type=file_type,
                                    dbkey=dbkey)
+
+@nebulizer.command()
+@click.option("--name",
+              help="list only quotas with matching name. Can "
+              "include glob-style wild-cards.")
+@click.option("--long","-l","long_listing",is_flag=True,
+              help="use a long listing format that includes lists "
+              "of associated users and groups.")
+@click.argument("galaxy")
+@pass_context
+def list_quotas(context,galaxy,name,long_listing):
+    """
+    List quotas in Galaxy instance.
+
+    Prints details of quotas in GALAXY instance.
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # List users
+    sys.exit(quotas.list_quotas(gi,name=name,
+                                long_listing_format=long_listing))
 
 @nebulizer.command()
 @click.argument("galaxy")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1259,12 +1259,15 @@ def quotaadd(context,galaxy,name,quota,description=None,
 @click.option('-R','--remove-groups',metavar="GROUP[,GROUP...]",
               help="list of group names to disassociate from "
               "the quota, separated by commas.")
+@click.option('-u','--undelete',is_flag=True,
+              help="restores a previously deleted quota")
 @click.argument("galaxy")
 @click.argument("quota")
 @pass_context
 def quotamod(context,galaxy,quota,name=None,description=None,
              quota_size=None,default_for=None,add_users=None,
-             remove_users=None,add_groups=None,remove_groups=None):
+             remove_users=None,add_groups=None,remove_groups=None,
+             undelete=False):
     """
     Modify an existing quota.
 
@@ -1275,7 +1278,8 @@ def quotamod(context,galaxy,quota,name=None,description=None,
     or quota size and type.
 
     Users and groups can also be associated with or
-    disassociated from the quota.
+    disassociated from the quota, and deleted quotas can
+    be restored and modified.
     """
     # Get a Galaxy instance
     gi = context.galaxy_instance(galaxy)
@@ -1307,7 +1311,8 @@ def quotamod(context,galaxy,quota,name=None,description=None,
                           add_users=add_users,
                           remove_users=remove_users,
                           add_groups=add_groups,
-                          remove_groups=remove_groups))
+                          remove_groups=remove_groups,
+                          undelete=undelete))
 
 @nebulizer.command()
 @click.argument("galaxy")

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1154,12 +1154,17 @@ def add_library_datasets(context,galaxy,dest,file,file_type,
 @click.option("--name",
               help="list only quotas with matching name. Can "
               "include glob-style wild-cards.")
+@click.option("--status",
+              type=click.Choice(['active','deleted','all']),
+              default='active',
+              help="list quotas with the specified status; can be "
+              "one of 'active', 'deleted', 'all' (default: 'active')")
 @click.option("--long","-l","long_listing",is_flag=True,
               help="use a long listing format that includes lists "
               "of associated users and groups.")
 @click.argument("galaxy")
 @pass_context
-def list_quotas(context,galaxy,name,long_listing):
+def list_quotas(context,galaxy,name,status,long_listing):
     """
     List quotas in Galaxy instance.
 
@@ -1172,6 +1177,7 @@ def list_quotas(context,galaxy,name,long_listing):
         sys.exit(1)
     # List users
     sys.exit(quotas.list_quotas(gi,name=name,
+                                status=status,
                                 long_listing_format=long_listing))
 
 @nebulizer.command()

--- a/nebulizer/groups.py
+++ b/nebulizer/groups.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# groups: functions for managing groups
+import logging
+from bioblend import galaxy
+
+# Logging
+logger = logging.getLogger(__name__)
+
+class Group(object):
+    """
+    Class wrapping extraction of group data
+
+    Provides an interface for accessing data about a group
+    in a Galaxy instance, which has been retrieved via a
+    a call to the Galaxy API using bioblend.
+
+    """
+    def __init__(self,group_data):
+        """
+        Create a new Group instance
+
+        ``group_data`` is a dictionary returned by a
+        call to bioblend, for example:
+
+        >>> for group_data in galaxy.groups.GroupClient(gi).get_groups():
+        >>>    print(Group(group_data).name)
+
+        """
+        # Initialise
+        self.id = group_data['id']
+        self.name = group_data['name']
+        # Populate with additional data items
+        self.update(group_data)
+
+    def update(self,group_data):
+        """
+        Update the data items associated with the group
+
+        ``group_data`` is a dictionary returned by a
+        call to bioblend, for example:
+
+        >>> group.update(galaxy.groups.GroupClient(gi).show_group(group.id))
+
+        """
+        # Check this is the same user ID
+        if group_data['id'] != self.id:
+            raise Exception("Tried to update data for user ID '%s' "
+                            "with data for user ID '%s'" %
+                            (self.id,
+                             group_data['id']))
+        # Update the attributes
+        for attr in group_data.keys():
+            try:
+                setattr(self,attr,group_data[attr])
+            except AttributeError:
+                pass

--- a/nebulizer/groups.py
+++ b/nebulizer/groups.py
@@ -55,3 +55,25 @@ class Group(object):
                 setattr(self,attr,group_data[attr])
             except AttributeError:
                 pass
+
+# Functions
+
+def get_groups(gi):
+    """
+    Return list of groups in a Galaxy instance
+
+    Arguments:
+      gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
+
+    Returns:
+      list: list of Group objects.
+
+    """
+    groups = []
+    group_client = galaxy.groups.GroupsClient(gi)
+    # Get (undeleted) groups
+    for group_data in group_client.get_groups():
+        group = Group(user_data)
+        group.update(group_client.show_group(group.id))
+        groups.append(group)
+    return groups

--- a/nebulizer/quotas.py
+++ b/nebulizer/quotas.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+#
+# quotas: functions for managing quotas
+import logging
+import fnmatch
+from bioblend import galaxy
+from bioblend import ConnectionError
+from .users import User
+from .groups import Group
+
+# Logging
+logger = logging.getLogger(__name__)
+
+class Quota(object):
+    """
+    Class wrapping extraction of quota data
+
+    Provides an interface for accessing data about a quota
+    in a Galaxy instance, which has been retrieved via a
+    a call to the Galaxy API using bioblend.
+
+    """
+    def __init__(self,quota_data):
+        """
+        Create a new Quota instance
+
+        ``quota_data`` is a dictionary returned by a
+        call to bioblend, for example:
+
+        >>> for data in galaxy.quotas.QuotaClient(gi).get_quotas():
+        >>>    print(Quota(data).name)
+
+        Data can be supplemented by calling the
+        ``update`` method with another dictionary.
+
+        """
+        # Initialise
+        self.id = quota_data['id']
+        self.name = quota_data['name']
+        self.bytes = None
+        self.default = None
+        self.description = None
+        self.display_amount = None
+        self.groups = None
+        self.operation = None
+        self.users = None
+        # Populate with additional data items
+        self.update(quota_data)
+
+    @property
+    def default_for(self):
+        """
+        Returns class of user that quota is default for
+
+        Will be 'registered', 'unregistered' or None.
+        """
+        if self.default:
+            return self.default[0]['type']
+        return None
+
+    @property
+    def list_users(self):
+        """
+        Returns list of associated User instances
+        """
+        if self.users:
+            return [User(u['user']) for u in self.users]
+        return []
+
+    @property
+    def list_groups(self):
+        """
+        Returns list of associated Group instances
+        """
+        if self.groups:
+            return [Group(g['group']) for g in self.groups]
+        return []
+
+    def update(self,quota_data):
+        """
+        Update the data items associated with the quota
+
+        ``quota_data`` is a dictionary returned by a
+        call to bioblend, for example:
+
+        >>> user.update(galaxy.users.UserClient(gi).show_user(user.id))
+
+        """
+        # Check this is the same user ID
+        if quota_data['id'] != self.id:
+            raise Exception("Tried to update data for quota ID '%s' "
+                            "with data for quota ID '%s'" %
+                            (self.id,
+                             quota_data['id']))
+        # Update the attributes
+        for attr in quota_data.keys():
+            try:
+                setattr(self,attr,quota_data[attr])
+            except AttributeError:
+                pass
+
+# Functions
+
+def get_quotas(gi):
+    """
+    Return list of quotas from a Galaxy instance
+
+    Arguments:
+      gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
+
+    Returns:
+      list: list of Quota objects.
+
+    """
+    quotas = []
+    quota_client = galaxy.quotas.QuotaClient(gi)
+    for quota_data in quota_client.get_quotas():
+        quota = Quota(quota_data)
+        quota.update(quota_client.show_quota(quota.id))
+        quotas.append(quota)
+    return quotas
+
+def list_quotas(gi,name=None,long_listing_format=False):
+    """
+    List quotas in Galaxy instance
+
+    Arguments:
+      gi    : Galaxy instance
+      name  : optionally, only list matching quota names
+      long_listing_format (boolean): if True then use a
+        long listing format when reporting items
+
+    """
+    # Get quota data
+    try:
+        quotas = get_quotas(gi)
+    except ConnectionError as ex:
+        logger.fatal("Failed to get quota list: %s (%s)" % (ex.body,
+                                                            ex.status_code))
+        return 1
+    # Filter quota list on supplied name
+    if name:
+        name = name.lower()
+        quotas = [q for q in quotas
+                  if fnmatch.fnmatch(q.name.lower(),name)]
+    # Report quotas
+    quotas.sort(key=lambda q: q.name.lower())
+    for quota in quotas:
+        n_users = len(quota.list_users)
+        n_groups = len(quota.list_groups)
+        if not long_listing_format:
+            # Collect data items to report on a single line
+            display_items = [quota.name,
+                             "%s%s" % (quota.operation,
+                                       quota.display_amount),
+                             "%s" % quota.default_for
+                             if quota.default_for else '',
+                             "%s user%s" %
+                             (n_users,'' if n_users == 1 else 's'),
+                             "%s group%s" %
+                             (n_groups,'' if n_groups == 1 else 's')]
+            print('\t'.join([str(x) for x in display_items]))
+        else:
+            # Long listing format reports each quota in
+            # a block
+            print("Quota name : %s" % quota.name)
+            print("Description: %s" % quota.description)
+            print("Operation  : %s" % quota.operation)
+            print("Amount     : %s" % quota.display_amount)
+            print("Default    : %s" % quota.default_for)
+            print("%s user%s" % (n_users,'' if n_users == 1 else 's'))
+            for user in quota.list_users:
+                print("\t%s" % user.email)
+            print("%s group%s" % (n_groups,'' if n_groups == 1 else 's'))
+            for group in quota.list_groups:
+                print("\t%s" % group.name)
+            print("")
+    print("total %s" % len(quotas))

--- a/nebulizer/quotas.py
+++ b/nebulizer/quotas.py
@@ -16,9 +16,9 @@ from .groups import get_groups
 logger = logging.getLogger(__name__)
 
 # Constants
-VALID_DEFAULTSs = ('registered',
-                   'unregistered',
-                   'no')
+VALID_DEFAULTS = ('registered',
+                  'unregistered',
+                  'no')
 
 # Classes
 

--- a/test/test_quotas.py
+++ b/test/test_quotas.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+
+import unittest
+from nebulizer.quotas import Quota
+from nebulizer.quotas import handle_quota_spec
+
+class TestQuota(unittest.TestCase):
+    """
+    Tests for the 'Quota' class
+
+    """
+    def test_load_quota_data_minimal(self):
+        # Data returned from galaxy.quotas.QuotaClient(gi).get_quotas()
+        quota_data = { u'model_class': u'Quota',
+                       u'id': u'f2db41e1fa331b3e',
+                       u'name': u'NGS analyst',
+                       u'url': u'/api/quotas/f2db41e1fa331b3e' }
+        quota = Quota(quota_data)
+        self.assertEqual(quota.id,'f2db41e1fa331b3e')
+        self.assertEqual(quota.name,'NGS analyst')
+        self.assertEqual(quota.description,None)
+        self.assertEqual(quota.operation,None)
+        self.assertEqual(quota.bytes,None)
+        self.assertEqual(quota.display_amount,None)
+        self.assertEqual(quota.default_for,None)
+        self.assertEqual(quota.list_users,[])
+        self.assertEqual(quota.list_groups,[])
+    def test_load_quota_data_full(self):
+        # Data returned from galaxy.quotas.QuotaClient(gi).show_quota()
+        quota_data = { u'users': [],
+                       u'description': u'Quota for BCF',
+                       u'default': [],
+                       u'bytes': 536870912000,
+                       u'display_amount': u'500.0 GB',
+                       u'groups': [],
+                       u'model_class': u'Quota',
+                       u'operation': u'=',
+                       u'id': u'a9a3a7ad1f6b4288',
+                       u'name': 'BCF User' }
+        quota = Quota(quota_data)
+        self.assertEqual(quota.id,'a9a3a7ad1f6b4288')
+        self.assertEqual(quota.name,'BCF User')
+        self.assertEqual(quota.description,'Quota for BCF')
+        self.assertEqual(quota.operation,'=')
+        self.assertEqual(quota.bytes,536870912000)
+        self.assertEqual(quota.display_amount,'500.0 GB')
+        self.assertEqual(quota.default_for,None)
+        self.assertEqual(quota.list_users,[])
+        self.assertEqual(quota.list_groups,[])
+    def test_load_quota_data_full_users_and_groups(self):
+        # Data returned from galaxy.quotas.QuotaClient(gi).show_quota()
+        quota_data = { u'users':
+                       [
+                           { u'model_class': u'UserQuotaAssociation',
+                             u'user': { u'username': u'galaxy-user',
+                                        u'total_disk_usage': 242167080660.0,
+                                        u'deleted': False,
+                                        u'nice_total_disk_usage': u'225.5 GB',
+                                        u'email': u'galaxy.user@galaxy.org',
+                                        u'last_password_change':
+                                        u'2019-06-19T08:59:24.869868',
+                                        u'active': True,
+                                        u'model_class': u'User',
+                                        u'id': '89b5001534959253' }
+                           }
+                       ],
+                       u'description': u'Quota for BCF',
+                       u'default': [],
+                       u'bytes': 536870912000,
+                       u'display_amount': u'500.0 GB',
+                       u'groups':
+                       [
+                           { u'model_class': u'GroupQuotaAssociation',
+                             u'group': { u'model_class': u'Group',
+                                         u'id': u'568bb93d6fbfd316',
+                                         u'name': u'BCF Staff' }
+                           }
+                       ],
+                       u'model_class': u'Quota',
+                       u'operation': u'=',
+                       u'id': u'a9a3a7ad1f6b4288',
+                       u'name': 'BCF User' }
+        quota = Quota(quota_data)
+        self.assertEqual(quota.id,'a9a3a7ad1f6b4288')
+        self.assertEqual(quota.name,'BCF User')
+        self.assertEqual(quota.description,'Quota for BCF')
+        self.assertEqual(quota.operation,'=')
+        self.assertEqual(quota.bytes,536870912000)
+        self.assertEqual(quota.display_amount,'500.0 GB')
+        self.assertEqual(quota.default_for,None)
+        self.assertEqual([u.username for u in quota.list_users],
+                         ['galaxy-user',])
+        self.assertEqual([g.name for g in quota.list_groups],
+                         ['BCF Staff',])
+
+class TestHandleQuotaSpec(unittest.TestCase):
+    """
+    Tests for the 'handle_quota_spec' function
+    """
+    def test_handle_quota_spec(self):
+        self.assertEqual(handle_quota_spec("=500GB"),
+                         ('=','500GB'))
+    def test_handle_quota_spec_no_operation(self):
+        self.assertEqual(handle_quota_spec("500GB"),
+                         ('=','500GB'))
+
+        


### PR DESCRIPTION
WIP PR which implements new commands to query and manage quotas in Galaxy instances:

* `quotas`: report details of quotas defined in an instance;
* `quotaadd`: make a new quote in an instance.
* `quotamod`: update an existing quota
* `quotadel`: deletes an existing quota