### PR TITLE
Improve clarity of output from 'list_libraries'

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -978,11 +978,14 @@ def search_toolshed(context,toolshed,query_string,galaxy,long_listing):
 @nebulizer.command()
 @click.option('-l','long_listing',is_flag=True,
               help="use a long listing format that includes "
-              "ids, descriptions, file sizes, dbkeys and paths)")
+              "descriptions, file sizes, dbkeys and paths)")
+@click.option('--show_id',is_flag=True,
+              help="include internal Galaxy IDs for data "
+              "libraries, folders and datasets.")
 @click.argument("galaxy")
 @click.argument("path",required=False)
 @pass_context
-def list_libraries(context,galaxy,path,long_listing):
+def list_libraries(context,galaxy,path,long_listing,show_id):
     """
     List data libraries and contents.
 
@@ -1001,9 +1004,13 @@ def list_libraries(context,galaxy,path,long_listing):
     if path:
         sys.exit(libraries.list_library_contents(
             gi,path,
-            long_listing_format=long_listing))
+            long_listing_format=long_listing,
+            show_id=show_id))
     else:
-        sys.exit(libraries.list_data_libraries(gi))
+        sys.exit(libraries.list_data_libraries(
+            gi,
+            long_listing_format=long_listing,
+            show_id=show_id))
 
 @nebulizer.command()
 @click.option('-d','--description',

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -167,6 +167,68 @@ class Credentials(object):
                         return (url,api_key)
         raise KeyError("'%s': not found" % name)
 
+class Reporter(object):
+    """
+    Class for reporting column data
+
+    Given multiple "lines" of column data (supplied
+    as lists), pretty print the data in columns.
+
+    Example usage:
+
+    >>> output = Reporter()
+    >>> output.append(['Some data',1.0,3])
+    >>> output.append(['More stuff',21.9,19])
+    >>> output.report()
+    Some data   1.0   3
+    More stuff  21.9  19
+    """
+    def __init__(self):
+        """
+        New Reporter instance
+        """
+        self._content = list()
+        self._field_widths = list()
+    def append(self,line):
+        """
+        Add a line of data
+
+        Arguments:
+          line (list): list of data items to
+            append
+        """
+        self._content.append(line)
+        for ix,item in enumerate(line):
+            try:
+                self._field_widths[ix] = max(self._field_widths[ix],
+                                            len(str(item)))
+            except IndexError:
+                self._field_widths.append(len(str(item)))
+    @property
+    def nlines(self):
+        """
+        Number of lines stored
+        """
+        return len(self._content)
+    def report(self,delimiter='  ',padding=True):
+        """
+        Pretty-print the data
+
+        Arguments:
+          delimiter (str): delimiter to use (defaults
+            to two space characters i.e. '  ')
+          padding (bool): if True then line up columns
+            of data by padding with spaces
+        """
+        if padding:
+            for line in self._content:
+                print(delimiter.join(["%-*s" % (width,str(item))
+                                      for width,item in zip(self._field_widths,
+                                                            line)]))
+        else:
+            for line in self._content:
+                print(delimiter.join([str(item) for item in line]))
+
 def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
                         verify_ssl=True):
     """

--- a/nebulizer/libraries.py
+++ b/nebulizer/libraries.py
@@ -5,22 +5,40 @@ import logging
 import os
 import fnmatch
 from .core import get_current_user
+from .core import Reporter
 from bioblend import galaxy
 import logging
 
 logger = logging.getLogger(__name__)
 
-def list_data_libraries(gi):
+def list_data_libraries(gi,long_listing_format=False,show_id=False):
     """
     Return list of data libraries
 
     Arguments:
       gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
+      long_listing_format (boolean): if True then use a
+        long listing format when reporting items
+      show_id (boolean): if True then also report the
+        internal Galaxy IDs for data library items
 
     """
-    for lib in galaxy.libraries.LibraryClient(gi).get_libraries():
-        print("%s\t%s\t%s" % (lib['name'],lib['description'],lib['id']))
-        ##print("%s" % lib)
+    output = Reporter()
+    libraries = sorted(galaxy.libraries.LibraryClient(gi).get_libraries(),
+                       key=lambda lib: lib['name'])
+    for lib in libraries:
+        display_items = [lib['name']]
+        if long_listing_format:
+            if lib['description']:
+                description = "'%s'" % lib['description']
+            else:
+                description = "[No description]"
+            display_items.append(description)
+        if show_id:
+            display_items.append(lib['id'])
+        output.append(display_items)
+    output.report()
+    print("total %d" % output.nlines)
 
 def library_id_from_name(gi,library_name):
     """
@@ -63,7 +81,8 @@ def folder_id_from_name(gi,library_id,folder_name):
             return folder['id']
     return None
 
-def list_library_contents(gi,path,long_listing_format=False):
+def list_library_contents(gi,path,long_listing_format=False,
+                          show_id=False):
     """
     Print contents of folder in data library
 
@@ -78,6 +97,8 @@ def list_library_contents(gi,path,long_listing_format=False):
         a folder in a library
       long_listing_format (boolean): if True then use a
         long listing format when reporting items
+      show_id (boolean): if True then also report the
+        internal Galaxy IDs for data library items
 
     """
     # Get name and id for parent data library
@@ -106,6 +127,7 @@ def list_library_contents(gi,path,long_listing_format=False):
             pass
     # Output mode depends on whether we have wildcards
     if not wildcard_pattern:
+        output = Reporter()
         # Exact matches only
         matches = [x for x in library_contents if x['name'] == pattern]
         if not matches:
@@ -120,19 +142,26 @@ def list_library_contents(gi,path,long_listing_format=False):
                 contents = matches
         # Remove 'root' folder
         contents = [x for x in contents if x['name'] != '/']
-        # Report
-        if long_listing_format:
-            print("total %s" % len(contents))
         for item in contents:
             if item['type'] == 'folder':
-                report_folder(lib_client.show_folder(library_id,
-                                                     item['id']),
-                                    long_listing=long_listing_format)
+                output.append(report_folder(
+                    lib_client.show_folder(library_id,
+                                           item['id']),
+                    long_listing=long_listing_format,
+                    show_id=show_id))
             else:
-                report_dataset(dataset_client.show_dataset(item['id'],
-                                                           hda_ldda='ldda'),
-                               long_listing=long_listing_format)
+                output.append(report_dataset(
+                    item['id'],
+                    dataset_client.show_dataset(item['id'],
+                                                hda_ldda='ldda'),
+                    long_listing=long_listing_format,
+                    show_id=show_id))
+        # Report
+        output.report()
+        if long_listing_format:
+            print("total %s" % len(contents))
     else:
+        output = Reporter()
         # Number of levels to match
         nlevels = pattern.count('/')
         # Mixture of matches possible
@@ -159,7 +188,7 @@ def list_library_contents(gi,path,long_listing_format=False):
                 parent = os.path.split(item['name'])[0]+'/'
                 for folder in folders:
                     if folder['name'].startswith(parent):
-                        print("Parent = %s" % parent)
+                        #print("Parent = %s" % parent)
                         implicit_dataset = True
                         break
             # Item outside of folders
@@ -167,25 +196,37 @@ def list_library_contents(gi,path,long_listing_format=False):
                 datasets.append(item)
         # List the datasets
         for dataset in datasets:
-            report_dataset(dataset_client.show_dataset(item['id'],
-                                                       hda_ldda='ldda'),
-                           long_listing=long_listing_format)
+            output.append(report_dataset(
+                item['id'],
+                dataset_client.show_dataset(item['id'],
+                                            hda_ldda='ldda'),
+                long_listing=long_listing_format,
+                show_id=show_id))
+        output.report()
         # List the contents of each folder
         for folder in folders:
+            output = Reporter()
             print("\n%s:" % folder['name'])
             folder_contents = [x for x in library_contents if
                                os.path.split(x['name'])[0] == folder['name']]
-            if long_listing_format:
-                print("total %s" % len(folder_contents))
             for item in folder_contents:
                 if item['type'] == 'folder':
-                    report_folder(lib_client.show_folder(library_id,
-                                                         item['id']),
-                    long_listing=long_listing_format)
+                    output.append(report_folder(
+                        lib_client.show_folder(library_id,
+                                               item['id']),
+                        long_listing=long_listing_format,
+                        show_id=show_id))
                 else:
-                    report_dataset(dataset_client.show_dataset(item['id'],
-                                                               hda_ldda='ldda'),
-                                   long_listing=long_listing_format)
+                    output.append(report_dataset(
+                        item['id'],
+                        dataset_client.show_dataset(item['id'],
+                                                    hda_ldda='ldda'),
+                        long_listing=long_listing_format,
+                        show_id=show_id))
+            # Output to stdout
+            output.report()
+            if long_listing_format:
+                print("total %s" % len(folder_contents))
 
 def create_library(gi,name,description=None,synopsis=None):
     """
@@ -366,7 +407,7 @@ def normalise_folder_path(path):
     """
     return  '/'+'/'.join([x for x in path.split('/') if x != ''])
 
-def report_folder(folder_data,long_listing=False):
+def report_folder(folder_data,long_listing=False,show_id=False):
     """
     Report details of a library folder
 
@@ -375,17 +416,28 @@ def report_folder(folder_data,long_listing=False):
         appropriate call to bioblend
       long_listing_format (boolean): if True then use a
         long listing format when reporting items
+      show_id (boolean): if True then include the ID
 
     """
     logger.debug("%s" % folder_data)
+    display_items = ["%s/" % folder_data['name'],
+                     "folder"]
     if long_listing:
-        print("%s/\t%s\t%s" % (folder_data['name'],
-                               folder_data['description'],
-                               folder_data['id']))
-    else:
-        print("%s/" % os.path.split(folder_data['name'])[1])
+        if folder_data['description']:
+            description = "'%s'" % folder_data['description']
+        else:
+            description = "[No description]"
+        item_count = folder_data['item_count']
+        display_items.extend([description,
+                              "%d item%s" % (item_count,
+                                             's' if item_count != 1
+                                             else '')])
+    if show_id:
+        display_items.append(folder_data['id'])
+    return display_items
 
-def report_dataset(dataset_data,long_listing=False):
+def report_dataset(dataset_id,dataset_data,long_listing=False,
+                   show_id=False):
     """
     Report details of a library dataset
 
@@ -394,14 +446,30 @@ def report_dataset(dataset_data,long_listing=False):
         appropriate call to bioblend
       long_listing_format (boolean): if True then use a
         long listing format when reporting items
+      show_id (boolean): if True then include the ID
 
     """
     logger.debug("%s" % dataset_data)
+    display_items = [dataset_data['name'],
+                     dataset_data['file_ext']]
     if long_listing:
-        print('\t'.join([str(x) for x in (dataset_data['name'],
-                                          dataset_data['file_ext'],
-                                          dataset_data['genome_build'],
-                                          dataset_data['file_size'],
-                                          dataset_data['file_name'],)]))
-    else:
-        print("%s" % os.path.split(dataset_data['name'])[1])
+        file_size = display_file_size(dataset_data['file_size'])
+        display_items.extend([dataset_data['genome_build'],
+                              file_size,
+                              dataset_data['file_name']])
+    if show_id:
+        display_items.append("LLDA:%s" % dataset_id)
+    return display_items
+
+def display_file_size(file_size):
+    """
+    Convert a file size in bytes to a human-readable format e.g '5.6K'
+    """
+    units = ('K','M','G','T')
+    if file_size < 1024:
+        return "%d" % file_size
+    for unit in units:
+        file_size = float(file_size)/1024.0
+        if file_size < 1024:
+            break
+    return "%.1f%s" % (file_size,unit)

--- a/nebulizer/libraries.py
+++ b/nebulizer/libraries.py
@@ -158,8 +158,7 @@ def list_library_contents(gi,path,long_listing_format=False,
                     show_id=show_id))
         # Report
         output.report()
-        if long_listing_format:
-            print("total %s" % len(contents))
+        print("total %s" % len(contents))
     else:
         output = Reporter()
         # Number of levels to match
@@ -185,24 +184,15 @@ def list_library_contents(gi,path,long_listing_format=False,
             if item['type'] == 'folder':
                 continue
             else:
-                parent = os.path.split(item['name'])[0]+'/'
+                parent = os.path.split(item['name'])[0]
                 for folder in folders:
-                    if folder['name'].startswith(parent):
+                    if folder['name'] == parent:
                         #print("Parent = %s" % parent)
                         implicit_dataset = True
                         break
             # Item outside of folders
             if not implicit_dataset:
                 datasets.append(item)
-        # List the datasets
-        for dataset in datasets:
-            output.append(report_dataset(
-                item['id'],
-                dataset_client.show_dataset(item['id'],
-                                            hda_ldda='ldda'),
-                long_listing=long_listing_format,
-                show_id=show_id))
-        output.report()
         # List the contents of each folder
         for folder in folders:
             output = Reporter()
@@ -227,6 +217,19 @@ def list_library_contents(gi,path,long_listing_format=False,
             output.report()
             if long_listing_format:
                 print("total %s" % len(folder_contents))
+        # List the datasets
+        if datasets:
+            print("\n.:")
+            output = Reporter()
+            for dataset in datasets:
+                output.append(report_dataset(
+                    item['id'],
+                    dataset_client.show_dataset(item['id'],
+                                                hda_ldda='ldda'),
+                    long_listing=long_listing_format,
+                    show_id=show_id))
+            output.report()
+            print("total %s" % len(datasets))
 
 def create_library(gi,name,description=None,synopsis=None):
     """


### PR DESCRIPTION
PR which implements a number of updates to the output from the `list_libraries` command:

* Ensure outputs line up in columns (easier to read)
* Only display Galaxy IDs for library contents if `--show_id` is specified
* Show library dataset IDs (LDDA's) for datasets
* General improvements to reported information

PR includes a new class in the `core` module (`Reporter`) to help with outputting column data.