### PR TITLE
Improve clarity of output from 'list_users' command

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -301,9 +301,11 @@ def remove_key(context,alias):
 @click.option("--long","-l","long_listing",is_flag=True,
               help="use a long listing format that includes ids,"
               " disk usage and admin status.")
+@click.option("--show_id",is_flag=True,
+              help="include internal Galaxy user ID.")
 @click.argument("galaxy")
 @pass_context
-def list_users(context,galaxy,name,long_listing):
+def list_users(context,galaxy,name,long_listing,show_id):
     """
     List users in Galaxy instance.
 
@@ -316,7 +318,8 @@ def list_users(context,galaxy,name,long_listing):
         sys.exit(1)
     # List users
     sys.exit(users.list_users(gi,name=name,
-                              long_listing_format=long_listing))
+                              long_listing_format=long_listing,
+                              show_id=show_id))
 
 @nebulizer.command()
 @click.option('--password','-p',

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -148,6 +148,7 @@ def list_users(gi,name=None,long_listing_format=False,show_id=False):
                   fnmatch.fnmatch(u.email.lower(),name))]
     # Report users
     users.sort(key=lambda u: u.email.lower())
+    output = []
     for user in users:
         # Get additional user data
         user.update(galaxy.users.UserClient(gi).show_user(user.id))
@@ -171,7 +172,19 @@ def list_users(gi,name=None,long_listing_format=False,show_id=False):
         if show_id:
             # Also report the internal user ID
             display_items.append(user.id)
-        print('\t'.join([str(x) for x in display_items]))
+        output.append(display_items)
+    # Report user data
+    field_widths = []
+    for line in output:
+        for ix,item in enumerate(line):
+            item_width = len(str(item))
+            try:
+                field_widths[ix] = max(item_width,field_widths[ix])
+            except IndexError:
+                field_widths.append(item_width)
+    for line in output:
+        print('  '.join(["%-*s" % (width,str(item))
+                        for width,item in zip(field_widths,line)]))
     print("total %s" % len(users))
 
 def create_user(gi,email,username=None,passwd=None,only_check=False,

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -10,6 +10,7 @@ from bioblend import ConnectionError
 from mako.template import Template
 from .core import get_galaxy_config
 from .core import prompt_for_confirmation
+from .core import Reporter
 
 # Logging
 logger = logging.getLogger(__name__)
@@ -148,7 +149,7 @@ def list_users(gi,name=None,long_listing_format=False,show_id=False):
                   fnmatch.fnmatch(u.email.lower(),name))]
     # Report users
     users.sort(key=lambda u: u.email.lower())
-    output = []
+    output = Reporter()
     for user in users:
         # Get additional user data
         user.update(galaxy.users.UserClient(gi).show_user(user.id))
@@ -174,17 +175,7 @@ def list_users(gi,name=None,long_listing_format=False,show_id=False):
             display_items.append(user.id)
         output.append(display_items)
     # Report user data
-    field_widths = []
-    for line in output:
-        for ix,item in enumerate(line):
-            item_width = len(str(item))
-            try:
-                field_widths[ix] = max(item_width,field_widths[ix])
-            except IndexError:
-                field_widths.append(item_width)
-    for line in output:
-        print('  '.join(["%-*s" % (width,str(item))
-                        for width,item in zip(field_widths,line)]))
+    output.report()
     print("total %s" % len(users))
 
 def create_user(gi,email,username=None,passwd=None,only_check=False,


### PR DESCRIPTION
PR which improves the clarity of output from the `list_users` command:

* Ensure column-based data lines up (easier to read)
* Include the Galaxy ID for users if `--show_id` option is used.