### PR TITLE
'remove_key': check if key exists, and prompt for confirmation of removal

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -12,6 +12,7 @@ from .core import get_galaxy_instance
 from .core import get_current_user
 from .core import get_galaxy_config
 from .core import ping_galaxy_instance
+from .core import prompt_for_confirmation
 from .core import turn_off_urllib3_warnings
 from .core import Credentials
 from . import options
@@ -291,8 +292,13 @@ def remove_key(context,alias):
     ALIAS from the list of stored keys.
     """
     instances = Credentials()
-    if not instances.remove_key(alias):
+    if not instances.has_key(alias):
+        logger.fatal("No alias '%s' to remove" % alias)
         sys.exit(1)
+    print("Removing key for alias '%s'" % alias)
+    if prompt_for_confirmation("Proceed?"):
+        if not instances.remove_key(alias):
+            sys.exit(1)
 
 @nebulizer.command()
 @click.option("--name",

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -167,6 +167,16 @@ class Credentials(object):
                         return (url,api_key)
         raise KeyError("'%s': not found" % name)
 
+    def has_key(self,name):
+        """
+        Check if alias exists
+        """
+        try:
+            self.fetch_key(name)
+            return True
+        except KeyError:
+            return False
+
 class Reporter(object):
     """
     Class for reporting column data


### PR DESCRIPTION
PR which updates the `remove_key` command to check if the alias/key exists, and then prompts the user to confirm removal if it does.