### PR TITLE
'whoami': improve handling of errors

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1216,9 +1216,13 @@ def whoami(context,galaxy,):
     """
     logger.debug("Debugging mode")
     # Get a Galaxy instance
-    gi = context.galaxy_instance(galaxy)
+    try:
+        gi = context.galaxy_instance(galaxy)
+    except Exception as ex:
+        logger.warning(ex)
+        gi = None
     if gi is None:
-        logger.critical("Failed to connect to Galaxy instance")
+        logger.fatal("Failed to connect to Galaxy instance")
         sys.exit(1)
     user = get_current_user(gi)
     if user is None:


### PR DESCRIPTION
PR to improve how the `whoami` command handles errors from the Galaxy connection (e.g. if the user doesn't actually exist).