### PR TITLE
'uninstall_tool' update the --remove-from-disk option name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ Uninstall all installed revisions of a tool and remove from
 disk::
 
   nebulizer uninstall_tool localhost devteam/fastqc/* \
-    --remove-from-disk
+    --remove_from_disk
 
 ---------------------------------------------
 Searching for tool repositories on a Toolshed

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -878,7 +878,7 @@ def update_tool(context,galaxy,repository,
                                (install_resolver_dependencies== 'yes')))
 
 @nebulizer.command()
-@click.option('--remove-from-disk',is_flag=True,
+@click.option('--remove_from_disk',is_flag=True,
               help="remove the uninstalled tool from disk (otherwise "
               "tool is just deactivated).")
 @click.option('-y','--yes',is_flag=True,


### PR DESCRIPTION
PR which renames the `--remove-from-disk` option to `--remove_from_disk` for the `uninstall_tool` command.