### PR TITLE
Set minimum Bioblend version to 0.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'nebulizer = nebulizer.cli:nebulizer',]
     },
     license = 'AFL',
-    install_requires = ['bioblend',
+    install_requires = ['bioblend>=0.13.0',
                         'mako',
                         'click<=6.7'],
     test_suite = 'nose.collector',


### PR DESCRIPTION
PR which sets the minimum required `Bioblend` version for installation to 0.13.0 in `setup.py`.