### PR TITLE
'search_toolshed': display tool URL for the tool in the extended listing

### DIFF
--- a/nebulizer/search.py
+++ b/nebulizer/search.py
@@ -3,6 +3,7 @@
 # search: functions for searching toolshed
 import logging
 import string
+import os
 from fnmatch import fnmatch
 from .core import get_galaxy_instance
 from .core import Reporter
@@ -127,6 +128,7 @@ def search_toolshed(tool_shed,query_string,gi=None,
                 status = "*"
             else:
                 status = " "
+            url = os.path.join(tool_shed_url,"view",owner,name,changeset)
             # Print details
             if not long_listing_format:
                 display_items = [owner,name,
@@ -138,6 +140,7 @@ def search_toolshed(tool_shed,query_string,gi=None,
                 output.append(("Owner",owner))
                 output.append(("Revision","%s:%s" % (version,changeset)))
                 output.append(("Description",description))
+                output.append(("URL",url))
                 if gi is not None:
                     if installed:
                         output.append(("Installed","yes"))


### PR DESCRIPTION
PR which updates the `search_toolshed` command to include the tool URL in the extended listing output (i.e. when using `-l` option).