### PR TITLE
'update_tool': enable wildcards for repository owner and name to specify multiple tool repos

### DIFF
--- a/docs/tools.rst
+++ b/docs/tools.rst
@@ -103,6 +103,14 @@ except that a revision cannot be included. For example:
 
    nebulizer update_tool GALAXY devteam/fastqc
 
+It is also possible to include glob-style wildcards in the
+tool repository name and/or owner e.g. ``devteam/*`` or
+``bgruening/deeptools_*``. To request update of all tools:
+
+::
+
+   nebulizer update_tool GALAXY '*/*'
+
 .. note::
 
    ``update_tool`` doesn't uninstall the older versions of

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -855,6 +855,9 @@ def update_tool(context,galaxy,repository,
     - [ TOOLSHED ] OWNER TOOLNAME e.g.
     https://toolshed.g2.bx.psu.edu devteam fastqc
 
+    OWNER and TOOLNAME can include glob-style wildcards;
+    use '*/*' to update all tools.
+
     The tool must already be present in GALAXY and a newer
     changeset revision must be available. The update will
     be installed into the same tool panel section as the

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -828,7 +828,9 @@ def install_repositories(context,galaxy,file,
               "complete.")
 @click.option('--check-toolshed',is_flag=True,
               help="check installed revisions directly against those "
-              "available in the toolshed")
+              "available in the toolshed.")
+@click.option('-y','--yes',is_flag=True,
+              help="don't ask for confirmation of updates.")
 @click.argument("galaxy")
 @click.argument("repository",nargs=-1)
 @pass_context
@@ -836,7 +838,8 @@ def update_tool(context,galaxy,repository,
                 install_tool_dependencies,
                 install_repository_dependencies,
                 install_resolver_dependencies,
-                timeout,no_wait,check_toolshed):
+                timeout,no_wait,check_toolshed,
+                yes):
     """
     Update tool installed from toolshed.
 
@@ -884,7 +887,8 @@ def update_tool(context,galaxy,repository,
                                install_repository_dependencies=
                                (install_repository_dependencies== 'yes'),
                                install_resolver_dependencies=
-                               (install_resolver_dependencies== 'yes')))
+                               (install_resolver_dependencies== 'yes'),
+                               no_confirm=yes))
 
 @nebulizer.command()
 @click.option('--remove_from_disk',is_flag=True,

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -864,7 +864,7 @@ def update_tool(context,galaxy,repository,
     except Exception as ex:
         logger.fatal(ex)
         sys.exit(1)
-    print("Updating %s/%s from %s" % (repository,owner,toolshed))
+    print("Updating %s/%s from %s" % (owner,repository,toolshed))
     if revision is not None:
         logger.fatal("A revision ('%s') was also supplied "
                      "but this is not valid for tool update "

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1295,14 +1295,14 @@ def update_tool(gi,tool_shed,name,owner,
                                if not r.deleted]
         if not installed_revisions:
             logger.warning("%s/%s: no revisions currently installed" %
-                           (update_repo.owner,update_repo.name))
+                           (repo.owner,repo.name))
             continue
         # Find the latest installable revision
         if check_tool_shed:
             repo.update_tool_shed_revision_status()
         if not repo.tool_shed_revisions():
             logger.warning("%s/%s: no installable revisions found" %
-                           (update_repo.owner,update_repo.name))
+                           (repo.owner,repo.name))
             continue
         # Check there is an update available
         update_available = True

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1279,7 +1279,7 @@ def update_tool(gi,tool_shed,name,owner,
     repos = []
     for repo in get_repositories(gi):
         if repo.tool_shed == tool_shed and \
-           repo.owner == owner and \
+           fnmatch.fnmatch(repo.owner,owner) and \
            fnmatch.fnmatch(repo.name,name):
             repos.append(repo)
     if not repos:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1240,7 +1240,8 @@ def update_tool(gi,tool_shed,name,owner,
                 install_repository_dependencies=True,
                 install_resolver_dependencies=True,
                 timeout=600,poll_interval=10,
-                no_wait=False,check_tool_shed=False):
+                no_wait=False,check_tool_shed=False,
+                no_confirm=False):
     """
     Update a tool repository in a Galaxy instance
 
@@ -1274,6 +1275,8 @@ def update_tool(gi,tool_shed,name,owner,
         revisions against the tool shed, to determine if
         updates are available for the tool (default is
         False i.e. do not check status against toolshed)
+      no_confirm : if True then don't prompt to confirm the
+        uninstall operation.
     """
     # Locate the existing installation
     repos = []
@@ -1326,7 +1329,8 @@ def update_tool(gi,tool_shed,name,owner,
     for r in update_repos:
         print("\t%s %s/%s" % (r.tool_shed,r.owner,r.name))
     print("")
-    if not prompt_for_confirmation("Proceed?",default="n"):
+    if (not no_confirm) and \
+       (not prompt_for_confirmation("Proceed?",default="n")):
         print("Update cancelled")
         return TOOL_UPDATE_OK
     # Loop over repositories and try to update

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1350,7 +1350,8 @@ def update_tool(gi,tool_shed,name,owner,
                 tool_panel_section = tool.panel_section
                 break
         if tool_panel_section is None:
-            logger.warning("%s: no tool panel section found" % name)
+            logger.warning("%s/%s: no tool panel section found" %
+                           (update_repo.owner,update_repo.name))
         #print("Installing update under %s" % tool_panel_section)
         status = install_tool(
             gi,update_repo.tool_shed,update_repo.name,

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1276,55 +1276,85 @@ def update_tool(gi,tool_shed,name,owner,
         False i.e. do not check status against toolshed)
     """
     # Locate the existing installation
-    update_repo = None
+    repos = []
     for repo in get_repositories(gi):
         if repo.tool_shed == tool_shed and \
-           repo.name == name and \
-           repo.owner == owner:
-            update_repo = repo
-            break
-    if update_repo is None:
-        logger.critical("%s: unable to find repository to update" %
-                        name)
+           repo.owner == owner and \
+           fnmatch.fnmatch(repo.name,name):
+            repos.append(repo)
+    if not repos:
+        logger.critical("%s/%s: unable to find repositories to update" %
+                        (owner,name))
         return TOOL_UPDATE_FAIL
-    # Check there is at least one installed revision
-    installed_revisions = [r for r in update_repo.revisions()
-                           if not r.deleted]
-    if not installed_revisions:
-        logger.fatal("%s: no revisions currently installed" % name)
+    # Loop over matching repositories and check for
+    # installed revisions
+    update_repos = []
+    for repo in repos:
+        # Check there is at least one installed revision
+        installed_revisions = [r for r in repo.revisions()
+                               if not r.deleted]
+        if not installed_revisions:
+            logger.warning("%s/%s: no revisions currently installed" %
+                           (update_repo.owner,update_repo.name))
+            continue
+        # Find the latest installable revision
+        if check_tool_shed:
+            repo.update_tool_shed_revision_status()
+        if not repo.tool_shed_revisions():
+            logger.warning("%s/%s: no installable revisions found" %
+                           (update_repo.owner,update_repo.name))
+            continue
+        # Check there is an update available
+        update_available = True
+        for r in repo.revisions():
+            if not r.deleted and (r.latest_revision and
+                                  not r.tool_shed_has_newer_revision()):
+                print("%s/%s: version %s already the latest version" %
+                      (repo.owner,repo.name,r.revision_id))
+                update_available = False
+                break
+        # Repository can be updated
+        if update_available:
+            update_repos.append(repo)
+    # Check if there are any tools to update
+    if not update_repos:
+        logger.fatal("%s/%s: no repositories to update" % (owner,name))
         return TOOL_UPDATE_FAIL
-    # Update the toolshed status
-    if check_tool_shed:
-        update_repo.update_tool_shed_revision_status()
-    # Find latest installable revision
-    if not update_repo.tool_shed_revisions():
-        logger.critical("%s: no installable revisions found" % name)
-        return TOOL_UPDATE_FAIL
-    revision = update_repo.tool_shed_revisions()[-1]
-    # Check that there is an update available
-    for r in update_repo.revisions():
-        if not r.deleted and (r.latest_revision and
-                              not r.tool_shed_has_newer_revision()):
-            print("%s: version %s already the latest version" %
-                  (name,r.revision_id))
-            return TOOL_UPDATE_OK
-    # Locate tool panel section for existing tools
-    tool_panel_section = None
-    for tool in get_tools(gi):
-        if tool.tool_repo == update_repo.id:
-            tool_panel_section = tool.panel_section
-            break
-    if tool_panel_section is None:
-        logger.warning("%s: no tool panel section found" % name)
-    #print("Installing update under %s" % tool_panel_section)
-    return install_tool(
-        gi,tool_shed,name,owner,revision,
-        install_tool_dependencies=install_tool_dependencies,
-        install_repository_dependencies=install_repository_dependencies,
-        install_resolver_dependencies=install_resolver_dependencies,
-        tool_panel_section=tool_panel_section,
-        timeout=timeout,poll_interval=poll_interval,
-        no_wait=no_wait)
+    # Report what will be updated and confirm
+    print("The following tool repositories will be updated:\n")
+    for r in update_repos:
+        print("\t%s %s/%s" % (r.tool_shed,r.owner,r.name))
+    print("")
+    if not prompt_for_confirmation("Proceed?",default="n"):
+        print("Update cancelled")
+        return TOOL_UPDATE_OK
+    # Loop over repositories and try to update
+    update_status = TOOL_UPDATE_OK
+    for update_repo in update_repos:
+        #  Get latest revision
+        revision = update_repo.tool_shed_revisions()[-1]
+        # Locate tool panel section for existing tools
+        tool_panel_section = None
+        for tool in get_tools(gi):
+            if tool.tool_repo == update_repo.id:
+                tool_panel_section = tool.panel_section
+                break
+        if tool_panel_section is None:
+            logger.warning("%s: no tool panel section found" % name)
+        #print("Installing update under %s" % tool_panel_section)
+        status = install_tool(
+            gi,update_repo.tool_shed,update_repo.name,
+            update_repo.owner,revision,
+            install_tool_dependencies=install_tool_dependencies,
+            install_repository_dependencies=install_repository_dependencies,
+            install_resolver_dependencies=install_resolver_dependencies,
+            tool_panel_section=tool_panel_section,
+            timeout=timeout,poll_interval=poll_interval,
+            no_wait=no_wait)
+        if status != TOOL_INSTALL_OK:
+            update_status = TOOL_UPDATE_FAIL
+    # Return the final status
+    return update_status
 
 def uninstall_tool(gi,tool_shed,name,owner,revision,
                    remove_from_disk=False,no_confirm=False):

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1330,7 +1330,12 @@ def update_tool(gi,tool_shed,name,owner,
         return TOOL_UPDATE_OK
     # Loop over repositories and try to update
     update_status = TOOL_UPDATE_OK
-    for update_repo in update_repos:
+    for ix,update_repo in enumerate(update_repos):
+        if len(update_repos) > 1:
+            print("[%d/%d]: updating %s/%s" % (ix+1,
+                                               len(update_repos),
+                                               update_repo.owner,
+                                               update_repo.name))
         #  Get latest revision
         revision = update_repo.tool_shed_revisions()[-1]
         # Locate tool panel section for existing tools

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1294,23 +1294,24 @@ def update_tool(gi,tool_shed,name,owner,
         installed_revisions = [r for r in repo.revisions()
                                if not r.deleted]
         if not installed_revisions:
-            logger.warning("%s/%s: no revisions currently installed" %
-                           (repo.owner,repo.name))
+            logger.debug("%s/%s: no revisions currently installed" %
+                         (repo.owner,repo.name))
             continue
         # Find the latest installable revision
         if check_tool_shed:
             repo.update_tool_shed_revision_status()
         if not repo.tool_shed_revisions():
-            logger.warning("%s/%s: no installable revisions found" %
-                           (repo.owner,repo.name))
+            logger.debug("%s/%s: no installable revisions found" %
+                         (repo.owner,repo.name))
             continue
         # Check there is an update available
         update_available = True
         for r in repo.revisions():
             if not r.deleted and (r.latest_revision and
                                   not r.tool_shed_has_newer_revision()):
-                print("%s/%s: version %s already the latest version" %
-                      (repo.owner,repo.name,r.revision_id))
+                logger.debug("%s/%s: version %s already the latest "
+                             "version" %
+                             (repo.owner,repo.name,r.revision_id))
                 update_available = False
                 break
         # Repository can be updated


### PR DESCRIPTION
PR that updates the `update_tool` command to accept glob-style wildcards in tool repository owner and repository names, to specify multiple tool repositories.

NB this allows all repositories to be updated using the combination `*/*`.

PR also adds a `-y` option to override prompt to confirm update operations.