### PR TITLE
README: fix quickstart installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ for example:
 ::
 
   % virtualenv .venv
-  % sourc .venv/bin/activate
+  % source .venv/bin/activate
   % pip install nebulizer
 
 This will provide an executable called ``nebulizer`` with a number


### PR DESCRIPTION
PR that fixes a typo in the quickstart installation instructions in the `README` file.