### PR TITLE
list_users: add --status option to list 'deleted' and 'purged' users

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -15,6 +15,10 @@ instance:
 * ``-l``: returns extended information for each user (status,
   whether they are an admin user, disk usage and quota size
   and usage).
+* ``--status``: filter list on user status, which can be one of
+  ``active`` (the default), ``deleted`` (only list deleted
+  users which haven't been purged) or ``all`` (list all active,
+  deleted, and purged users).
 * ``--name``: filter list on user email (can include glob-style
   wildcards e.g. ``--name="*bloggs*"``).
 

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -307,6 +307,11 @@ def remove_key(context,alias):
 @click.option("--name",
               help="list only users with matching email or user "
               "name. Can include glob-style wild-cards.")
+@click.option("--status",
+              type=click.Choice(['active','deleted','purged','all']),
+              default='active',
+              help="list users with the specified status (default: "
+              "'active')")
 @click.option("--long","-l","long_listing",is_flag=True,
               help="use a long listing format that includes ids,"
               " disk usage and admin status.")
@@ -314,7 +319,7 @@ def remove_key(context,alias):
               help="include internal Galaxy user ID.")
 @click.argument("galaxy")
 @pass_context
-def list_users(context,galaxy,name,long_listing,show_id):
+def list_users(context,galaxy,name,status,long_listing,show_id):
     """
     List users in Galaxy instance.
 
@@ -328,6 +333,7 @@ def list_users(context,galaxy,name,long_listing,show_id):
     # List users
     sys.exit(users.list_users(gi,name=name,
                               long_listing_format=long_listing,
+                              status=status,
                               show_id=show_id))
 
 @nebulizer.command()


### PR DESCRIPTION
PR which adds a new option `--status` option to the `list_users` command, to allow listing of user accounts based on their status:

* `active`: (the default) only list active accounts
* `deleted`: only list accounts which are deleted but not yet purged
* `purged`: only list account which are purged
* `all`: list all accounts regardless of status