### PR TITLE
delete_user: fix the purging functionality

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -45,6 +45,18 @@ generated automatically from the email address.
    nebulizer delete_user GALAXY USER@DOMAIN
 
 * ``--purge``: purge the account as well as deleting
+  (or purge an unpurged account which has been previously
+  deleted)
+
+.. note::
+
+   Purging a user account marks the datasets and histories
+   associated with that account as deleted; these data will
+   then be removed when Galaxy's clean-up scripts are run.
+
+   For information on the clean-up scripts see the Galaxy
+   documentation at
+   https://galaxyproject.org/admin/config/performance/purge-histories-and-datasets/
 
 Creating batches of users from a template name
 ----------------------------------------------

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -50,9 +50,11 @@ generated automatically from the email address.
 
 .. note::
 
-   Purging a user account marks the datasets and histories
-   associated with that account as deleted; these data will
-   then be removed when Galaxy's clean-up scripts are run.
+   Purging a user account overwrites the email and username
+   for that account with random strings; it also marks the
+   datasets and histories associated with that account as
+   deleted. These data can then be removed from disk by
+   running Galaxy's clean-up scripts.
 
    For information on the clean-up scripts see the Galaxy
    documentation at

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -114,6 +114,26 @@ def get_users(gi,status='active'):
             users.append(user)
     return users
 
+def get_user(gi,email):
+    """
+    Get the user data corresponding to a username email
+
+    Arguments:
+      gi (bioblend.galaxy.GalaxyInstance): Galaxy instance
+      email : email address for the user
+
+    Returns:
+      User: 'User' instance, or None if no match.
+    """
+    try:
+        for u in get_users(gi,status='all'):
+            if fnmatch.fnmatch(u.email,email):
+                return u
+    except ConnectionError as ex:
+        logger.warning("Failed to get user list: %s (%s)" % (ex.body,
+                                                             ex.status_code))
+    return None
+
 def get_user_id(gi,email):
     """
     Get the user ID corresponding to a username email
@@ -125,15 +145,10 @@ def get_user_id(gi,email):
     Returns:
       String: user ID, or None if no match.
     """
-    user_id = None
     try:
-        for u in get_users(gi):
-            if fnmatch.fnmatch(u.email,email):
-                return u.id
-    except ConnectionError as ex:
-        logger.warning("Failed to get user list: %s (%s)" % (ex.body,
-                                                             ex.status_code))
-    return None
+        return get_user(gi,email).id
+    except AttributeError:
+        return None
 
 def list_users(gi,name=None,long_listing_format=False,status=False,
                show_id=False):

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -187,11 +187,15 @@ def list_users(gi,name=None,long_listing_format=False,status=False,
                  (fnmatch.fnmatch(u.username.lower(),name) or
                   fnmatch.fnmatch(u.email.lower(),name))]
     # Report users
-    users.sort(key=lambda u: u.email.lower())
+    users.sort(key=lambda u: u.email.lower()
+               if not (u.purged and '@' not in u.email) else '')
     output = Reporter()
     for user in users:
         # Collect data items to report
-        display_items = [user.email,user.username]
+        if user.purged and '@' not in user.email:
+            display_items = ['<purged>','<purged>']
+        else:
+            display_items = [user.email,user.username]
         if long_listing_format:
             # Long listing format includes:
             # - disk usage


### PR DESCRIPTION
PR which fixes a bug in the `delete_user` command, when trying to use the `--purge` option: essentially it wasn't possible to use the purging, as purge can only be applied to an already deleted account (resulting in a failure if `--purge` was specified for a undeleted account), and `delete_user` in Nebulizer only operates on undeleted accounts.

The fixes are:

 1. For undeleted accounts that are to deleted and purged in a single command: do an initial deletion followed by a purge in the single command invocation, and
 2. Allow deleted accounts to be operated on by `--purge`

In addition the documentation has been updated to clarify what purging a user account actually does.