### PR TITLE
ping/config commands: don't need to validate API key when connecting to Galaxy

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1150,7 +1150,7 @@ def config(context,galaxy,name=None):
     GALAXY. Use --name to filter which items are reported.
     """
     # Get a Galaxy instance
-    gi = context.galaxy_instance(galaxy)
+    gi = context.galaxy_instance(galaxy,validate_key=False)
     if gi is None:
         logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -124,7 +124,7 @@ class Context(object):
         self.no_verify = False
         self.debug = False
 
-    def galaxy_instance(self,alias):
+    def galaxy_instance(self,alias,validate_key=True):
         """
         Return Galaxy instance based on context
 
@@ -137,6 +137,7 @@ class Context(object):
             prompt="Password for %s: " % alias)
         gi = get_galaxy_instance(alias,api_key=self.api_key,
                                  email=email,password=password,
+                                 validate_key=validate_key,
                                  verify_ssl=(not self.no_verify))
         return gi
 

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1194,7 +1194,7 @@ def ping(context,galaxy,count,interval=5,timeout=None):
     while True:
         try:
             # Get a Galaxy instance
-            gi = context.galaxy_instance(galaxy_url)
+            gi = context.galaxy_instance(galaxy_url,validate_key=False)
             if gi is None:
                 click.echo("%s: failed to connect" % galaxy_url)
                 status_code = 1

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -257,7 +257,7 @@ class Reporter(object):
             print(out_line)
 
 def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
-                        verify_ssl=True):
+                        verify_ssl=True,validate_key=True):
     """
     Return Bioblend GalaxyInstance
 
@@ -289,7 +289,9 @@ def get_galaxy_instance(galaxy_url,api_key=None,email=None,password=None,
     if api_key is None:
         api_key = stored_key
     logger.debug("Connecting to %s" % galaxy_url)
-    if email is not None:
+    if not validate_key:
+        gi = galaxy.GalaxyInstance(url=galaxy_url)
+    elif email is not None:
         gi = galaxy.GalaxyInstance(url=galaxy_url,email=email,
                                    password=password)
     else:


### PR DESCRIPTION
PR which updates the `ping` and `config` commands so that the API key doesn't need to be supplied/validated when connecting to Galaxy - the underlying calls don't need an API key (but if one is supplied then it must be correct).

PR addresses issue #93.