### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 
 install:
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 # Configuration file to run tests on Travis-CI via GitHub notifications
-# See http://travis-ci.org/
+# See https://travis-ci.org/
 
 language: python
 python:
-  - "2.7"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # nebulizer documentation build configuration file, created by
 # sphinx-quickstart on Mon Oct 24 10:38:54 2016.
 #
@@ -43,8 +41,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'nebulizer'
-copyright = u'2016, Peter Briggs'
+project = 'nebulizer'
+copyright = '2016, Peter Briggs'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -199,8 +197,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'nebulizer.tex', u'nebulizer Documentation',
-   u'Peter Briggs', 'manual'),
+  ('index', 'nebulizer.tex', 'nebulizer Documentation',
+   'Peter Briggs', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -229,8 +227,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'nebulizer', u'nebulizer Documentation',
-     [u'Peter Briggs'], 1)
+    ('index', 'nebulizer', 'nebulizer Documentation',
+     ['Peter Briggs'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -243,8 +241,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'nebulizer', u'nebulizer Documentation',
-   u'Peter Briggs', 'nebulizer', 'One line description of project.',
+  ('index', 'nebulizer', 'nebulizer Documentation',
+   'Peter Briggs', 'nebulizer', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,8 +29,7 @@ with ``pip``, use the  following ``pip install`` idiom instead:
 
     $ pip install -U git+git://github.com/pjbriggs/nebulizer.git@devel
 
-Nebulizer should work with both Python 2.7 and recent Python 3
-versions.
+Nebulizer should work with recent Python 3 versions.
 
 Conda
 =====
@@ -47,4 +46,4 @@ Note that the version available via ``bioconda`` may lag the
 most recent version available via ``pip``.
 
 .. _pip: https://pip.pypa.io/
-.. _Conda: http://conda.pydata.org/docs/
+.. _Conda: https://conda.io/

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -113,7 +113,7 @@ def fetch_new_api_key(galaxy_url,email,password=None,verify=True):
                              verify_ssl=verify)
     return users.get_user_api_key(gi,username=email)
 
-class Context(object):
+class Context:
     """
     Provide context for nebulizer command
     """
@@ -864,7 +864,7 @@ def update_tool(context,galaxy,repository,
     except Exception as ex:
         logger.fatal(ex)
         sys.exit(1)
-    print("Updating %s/%s from %s" % (repository,owner,toolshed))
+    print(f"Updating {repository}/{owner} from {toolshed}")
     if revision is not None:
         logger.fatal("A revision ('%s') was also supplied "
                      "but this is not valid for tool update "
@@ -925,7 +925,7 @@ def uninstall_tool(context,galaxy,repository,remove_from_disk,
     except Exception as ex:
         logger.fatal(ex)
         sys.exit(1)
-    print("Uninstalling %s/%s%s from %s" % (repository,
+    print("Uninstalling {}/{}{} from {}".format(repository,
                                             owner,
                                             '/%s' % revision
                                             if revision is not None

--- a/nebulizer/core.py
+++ b/nebulizer/core.py
@@ -13,7 +13,7 @@ from bioblend.galaxy.client import ConnectionError
 
 logger = logging.getLogger(__name__)
 
-class Credentials(object):
+class Credentials:
     """Class for managing credentials for Galaxy instances
 
     Credentials for different galaxy instances can be
@@ -53,7 +53,7 @@ class Credentials(object):
         """
         key_names = []
         if os.path.exists(self._key_file):
-            with open(self._key_file,'r') as fp:
+            with open(self._key_file) as fp:
                 for line in fp:
                     if line.startswith('#') or not line.strip():
                         continue
@@ -78,7 +78,7 @@ class Credentials(object):
             logger.warning("Empty API key")
             return False
         with open(self._key_file,'a') as fp:
-            fp.write("%s\t%s\t%s\n" % (name,url,api_key))
+            fp.write(f"{name}\t{url}\t{api_key}\n")
         return True
 
     def remove_key(self,name):
@@ -158,7 +158,7 @@ class Credentials(object):
           Tuple: consisting of (GALAXY_URL,API_KEY)
         """
         if os.path.exists(self._key_file):
-            with open(self._key_file,'r') as fp:
+            with open(self._key_file) as fp:
                 for line in fp:
                     if line.startswith('#') or not line.strip():
                         continue
@@ -177,7 +177,7 @@ class Credentials(object):
         except KeyError:
             return False
 
-class Reporter(object):
+class Reporter:
     """
     Class for reporting column data
 
@@ -251,7 +251,7 @@ class Reporter(object):
         if not prefix:
             prefix = ''
         for line in output:
-            out_line = "%s%s" % (prefix,delimiter.join(line))
+            out_line = "{}{}".format(prefix,delimiter.join(line))
             if rstrip:
                 out_line = out_line.rstrip()
             print(out_line)

--- a/nebulizer/libraries.py
+++ b/nebulizer/libraries.py
@@ -73,7 +73,7 @@ def folder_id_from_name(gi,library_id,folder_name):
     """
     lib_client = galaxy.libraries.LibraryClient(gi)
     folder_name = normalise_folder_path(folder_name)
-    logger.debug("Looking for '%s' in library %s" % (folder_name,
+    logger.debug("Looking for '{}' in library {}".format(folder_name,
                                                       library_id))
     for folder in lib_client.get_folders(library_id):
         logger.debug("Checking '%s'" % folder['name'])
@@ -340,10 +340,10 @@ def add_library_datasets(gi,path,files,
     # Get name and id for parent data library
     lib_client = galaxy.libraries.LibraryClient(gi)
     library_id = library_id_from_name(gi,library_name)
-    print("Library name '%s' id '%s'" % (library_name,library_id))
+    print(f"Library name '{library_name}' id '{library_id}'")
     # Get id for parent folder
     folder_id = folder_id_from_name(gi,library_id,folder_path)
-    print("Folder name '%s' id '%s'" % (folder_path,folder_id))
+    print(f"Folder name '{folder_path}' id '{folder_id}'")
     if from_server:
         # Assume that files are on Galaxy fileserver not localhost
         filesystem_paths = '\n'.join(files)
@@ -475,4 +475,4 @@ def display_file_size(file_size):
         file_size = float(file_size)/1024.0
         if file_size < 1024:
             break
-    return "%.1f%s" % (file_size,unit)
+    return f"{file_size:.1f}{unit}"

--- a/nebulizer/search.py
+++ b/nebulizer/search.py
@@ -130,13 +130,13 @@ def search_toolshed(tool_shed,query_string,gi=None,
             # Print details
             if not long_listing_format:
                 display_items = [owner,name,
-                                 "%s:%s" % (version,changeset),
+                                 f"{version}:{changeset}",
                                  status]
                 output.append(display_items)
             else:
                 output.append(("Name",name))
                 output.append(("Owner",owner))
-                output.append(("Revision","%s:%s" % (version,changeset)))
+                output.append(("Revision",f"{version}:{changeset}"))
                 output.append(("Description",description))
                 if gi is not None:
                     if installed:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -27,7 +27,7 @@ TOOL_UNINSTALL_FAIL = 1
 
 # Classes
 
-class Tool(object):
+class Tool:
     """
     Class wrapping extraction of tool data
 
@@ -118,14 +118,14 @@ class Tool(object):
             tool_shed = '/'.join(ele[:-2])
             owner = ele[-2]
             repo = ele[-1]
-            search_string = "/repos/%s/%s/" % (owner,repo)
+            search_string = f"/repos/{owner}/{repo}/"
             i = self.config_file.index(search_string) + len(search_string)
             revision = self.config_file[i:].split('/')[0]
             return revision
         except (AttributeError,ValueError):
             return None
 
-class RepositoryRevision(object):
+class RepositoryRevision:
     """
     Class wrapping extraction of toolshed repository version data
 
@@ -264,7 +264,7 @@ class RepositoryRevision(object):
         return ':'.join((self.revision_number,
                          self.changeset_revision))
 
-class Repository(object):
+class Repository:
     """
     Class wrapping extraction of toolshed repository data
 
@@ -403,7 +403,7 @@ class Repository(object):
                          self.owner,
                          self.name))
 
-class ToolPanelSection(object):
+class ToolPanelSection:
     """
     Class wrapping extraction of tool panel sections
 
@@ -459,7 +459,7 @@ class ToolPanelSection(object):
         """
         return (self.model_class == "ToolSectionLabel")
 
-class ToolPanel(object):
+class ToolPanel:
     """
     Class wrapping extraction of tool panel
 
@@ -990,7 +990,7 @@ def list_installed_repositories(gi,name=None,
         for r in repos:
             # Print details
             repo,revision,tools = r
-            output.append(('%s %s' % (revision.status_indicator,
+            output.append(('{} {}'.format(revision.status_indicator,
                                       repo.name),
                            repo.tool_shed,
                            repo.owner,
@@ -1118,7 +1118,7 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
     install_status = tool_install_status(gi,tool_shed,owner,name,
                                          revision)
     if install_status.startswith("Installed"):
-        print("%s: already installed (status is \"%s\")" % (name,
+        print("{}: already installed (status is \"{}\")".format(name,
                                                             install_status))
         return TOOL_INSTALL_OK
     # Get available revisions
@@ -1141,7 +1141,7 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
     install_status = tool_install_status(gi,tool_shed,owner,name,
                                          revision)
     if install_status.startswith("Installed"):
-        print("%s: already installed (status is \"%s\")" % (name,
+        print("{}: already installed (status is \"{}\")".format(name,
                                                             install_status))
         return TOOL_INSTALL_OK
     # Look up tool panel section
@@ -1201,7 +1201,7 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
         install_status = tool_install_status(gi,tool_shed,owner,
                                              name,revision)
         if install_status.startswith("Installed"):
-            print("%s: installed (status is \"%s\")" % (name,
+            print("{}: installed (status is \"{}\")".format(name,
                                                         install_status))
             return TOOL_INSTALL_OK
         elif install_status.startswith("Installing") or \
@@ -1217,14 +1217,14 @@ def install_tool(gi,tool_shed,name,owner,revision=None,
                 return TOOL_INSTALL_PENDING
             # Monitor the tool installation status
             ntries += 1
-            status_msg = "%s: installing (status is \"%s\")" % (name,
+            status_msg = "{}: installing (status is \"{}\")".format(name,
                                                                 install_status)
             if status_msg != prev_status_msg:
                 print(status_msg)
                 prev_status_msg = status_msg
             time.sleep(poll_interval)
         else:
-            logger.critical("%s: failed (%s)" % (name,install_status))
+            logger.critical(f"{name}: failed ({install_status})")
             return TOOL_INSTALL_FAIL
     # Reaching here means timed out
     logger.critical("%s: timed out waiting for install" % name)
@@ -1348,7 +1348,7 @@ def uninstall_tool(gi,tool_shed,name,owner,revision,
                        and r.name == name
                        and r.owner == owner]
     if not uninstall_repos:
-        logger.fatal("%s/%s: no matching tool installed?" % (owner,name))
+        logger.fatal(f"{owner}/{name}: no matching tool installed?")
         return TOOL_UNINSTALL_FAIL
     elif len(uninstall_repos) > 1:
         logger.fatal("%s/%s: matches multiple installed tools?" %
@@ -1378,7 +1378,7 @@ def uninstall_tool(gi,tool_shed,name,owner,revision,
     # Report and confirm uninstall
     print("\nThe following tools will be uninstalled:\n")
     for r in remove_revisions:
-        print("\t%s %s/%s %s" % (tool_shed,owner,name,r.revision_id))
+        print(f"\t{tool_shed} {owner}/{name} {r.revision_id}")
     print("")
     if (not no_confirm) and \
        (not prompt_for_confirmation("Proceed?",default="n")):
@@ -1388,7 +1388,7 @@ def uninstall_tool(gi,tool_shed,name,owner,revision,
     uninstall_status = TOOL_UNINSTALL_OK
     for revision in remove_revisions:
         try:
-            print("%s/%s: requesting uninstall" % (name,
+            print("{}/{}: requesting uninstall".format(name,
                                                    revision.revision_id))
             tool_shed_client = galaxy.toolshed.ToolShedClient(gi)
             result = tool_shed_client.uninstall_repository_revision(

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -456,13 +456,6 @@ def delete_user(gi,email,purge=False,no_confirm=False):
                      "--purge)" % email)
         return 0
     # Prompt user for confirmation
-    if no_confirm or prompt_for_confirmation(
-            "Delete {}user '{}'?".format(" & purge" if purge else '',
-                                     email),
-            default="n"):
-        try:
-            galaxy.users.UserClient(gi).delete_user(user_id,purge=purge)
-            print("Deleted {}user '{}'".format(" & purged" if purge else '',
     if not user.deleted:
         prompt = "Delete {}user '{}'?".format("& purge " if purge else '',
                                           email)

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # Classes
 
-class User(object):
+class User:
     """
     Class wrapping extraction of user data
 
@@ -112,7 +112,7 @@ def get_user_id(gi,email):
             if fnmatch.fnmatch(u.email,email):
                 return u.id
     except ConnectionError as ex:
-        logger.warning("Failed to get user list: %s (%s)" % (ex.body,
+        logger.warning("Failed to get user list: {} ({})".format(ex.body,
                                                              ex.status_code))
     return None
 
@@ -131,7 +131,7 @@ def list_users(gi,name=None,long_listing_format=False,show_id=False):
     try:
         users = get_users(gi)
     except ConnectionError as ex:
-        logger.fatal("Failed to get user list: %s (%s)" % (ex.body,
+        logger.fatal("Failed to get user list: {} ({})".format(ex.body,
                                                            ex.status_code))
         return 1
     # Get Galaxy config data to determine if quotas are enabled
@@ -338,7 +338,7 @@ def create_batch_of_users(gi,tsv,only_check=False,mako_template=None):
     # Open file
     print("Reading data from file '%s'" % tsv)
     users = {}
-    for line in open(tsv,'r'):
+    for line in open(tsv):
         # Skip blank or comment lines
         if line.startswith('#') or not line.strip():
             continue
@@ -366,7 +366,7 @@ def create_batch_of_users(gi,tsv,only_check=False,mako_template=None):
             name = get_username_from_login(email)
         if check_new_user_info(gi,email,name):
             users[email] = { 'name': name, 'passwd': passwd }
-            print("%s\t%s\t%s" % (email,'*****',name))
+            print("{}\t{}\t{}".format(email,'*****',name))
     if only_check:
         return 0
     # Make the accounts
@@ -401,16 +401,16 @@ def delete_user(gi,email,purge=False,no_confirm=False):
         return 1
     # Prompt user for confirmation
     if no_confirm or prompt_for_confirmation(
-            "Delete %suser '%s'?" % (" & purge" if purge else '',
+            "Delete {}user '{}'?".format(" & purge" if purge else '',
                                      email),
             default="n"):
         try:
             galaxy.users.UserClient(gi).delete_user(user_id,purge=purge)
-            print("Deleted %suser '%s'" % (" & purged" if purge else '',
+            print("Deleted {}user '{}'".format(" & purged" if purge else '',
                                            email))
             return 0
         except ConnectionError as ex:
-            logger.fatal("Failed to delete user: %s (%s)" % (ex.body,
+            logger.fatal("Failed to delete user: {} ({})".format(ex.body,
                                                              ex.status_code))
             return 1
     else:

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,11 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        "Programming Language :: Python :: 3 :: Only",
     ],
     include_package_data=True,
     zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     test_suite = 'nose.collector',
     tests_require = ['nose'],
     platforms="Posix; MacOS X; Windows",
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -13,17 +13,17 @@ class TestTool(unittest.TestCase):
 
     """
     def test_load_tool_data(self):
-        tool_data = { u'panel_section_name': u'NGS: Mapping',
-                      u'description': u'Reports on methylation status of reads mapped by Bismark',
-                      u'config_file': u'/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/bismark/0f8646f22b8d/bismark/bismark_bowtie_wrapper.xml',
-                      u'name': u'Bismark Meth. Extractor',
-                      u'panel_section_id': u'solexa_tools',
-                      u'version': u'0.10.2',
-                      u'link': u'/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fbismark%2Fbismark_methylation_extractor%2F0.10.2',
-                      u'min_width': -1,
-                      u'model_class': u'Tool',
-                      u'id': u'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.10.2',
-                      u'target': u'galaxy_main'}
+        tool_data = { 'panel_section_name': 'NGS: Mapping',
+                      'description': 'Reports on methylation status of reads mapped by Bismark',
+                      'config_file': '/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/bgruening/bismark/0f8646f22b8d/bismark/bismark_bowtie_wrapper.xml',
+                      'name': 'Bismark Meth. Extractor',
+                      'panel_section_id': 'solexa_tools',
+                      'version': '0.10.2',
+                      'link': '/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fbismark%2Fbismark_methylation_extractor%2F0.10.2',
+                      'min_width': -1,
+                      'model_class': 'Tool',
+                      'id': 'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.10.2',
+                      'target': 'galaxy_main'}
         tool = Tool(tool_data)
         self.assertEqual(tool.name,'Bismark Meth. Extractor')
         self.assertEqual(tool.description,
@@ -39,16 +39,16 @@ class TestTool(unittest.TestCase):
         self.assertEqual(tool.tool_changeset,'0f8646f22b8d')
 
     def test_load_tool_data_no_config_file(self):
-        tool_data = { u'panel_section_name': u'NGS: Mapping',
-                      u'description': u'Reports on methylation status of reads mapped by Bismark',
-                      u'name': u'Bismark Meth. Extractor',
-                      u'panel_section_id': u'solexa_tools',
-                      u'version': u'0.10.2',
-                      u'link': u'/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fbismark%2Fbismark_methylation_extractor%2F0.10.2',
-                      u'min_width': -1,
-                      u'model_class': u'Tool',
-                      u'id': u'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.10.2',
-                      u'target': u'galaxy_main'}
+        tool_data = { 'panel_section_name': 'NGS: Mapping',
+                      'description': 'Reports on methylation status of reads mapped by Bismark',
+                      'name': 'Bismark Meth. Extractor',
+                      'panel_section_id': 'solexa_tools',
+                      'version': '0.10.2',
+                      'link': '/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fbgruening%2Fbismark%2Fbismark_methylation_extractor%2F0.10.2',
+                      'min_width': -1,
+                      'model_class': 'Tool',
+                      'id': 'toolshed.g2.bx.psu.edu/repos/bgruening/bismark/bismark_methylation_extractor/0.10.2',
+                      'target': 'galaxy_main'}
         tool = Tool(tool_data)
         self.assertEqual(tool.name,'Bismark Meth. Extractor')
         self.assertEqual(tool.description,
@@ -64,17 +64,17 @@ class TestTool(unittest.TestCase):
         self.assertEqual(tool.tool_changeset,None)
 
     def test_load_tool_data_toolshed_has_prefix(self):
-        tool_data = { u'panel_section_name': u'Local Toolshed',
-                      u'config_file': u'/galaxy/shed_tools/192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/2f0a1f1a5725/rnachipintegrator/rnachipintegrator_wrapper.xml',
-                      u'description': u"Integrated analysis of 'gene' and 'peak' data",
-                      u'panel_section_id': u'local_toolshed',
-                      u'version': u'1.0.1.0',
-                      u'link': u'/galaxy_dev/tool_runner?tool_id=192.168.60.164%2Ftoolshed%2Frepos%2Fpjbriggs%2Frnachipintegrator%2Frnachipintegrator_wrapper%2F1.0.1.0',
-                      u'target': u'galaxy_main',
-                      u'min_width': -1,
-                      u'model_class': u'Tool',
-                      u'id': u'192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.1.0',
-                      u'name': u'RnaChipIntegrator'}
+        tool_data = { 'panel_section_name': 'Local Toolshed',
+                      'config_file': '/galaxy/shed_tools/192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/2f0a1f1a5725/rnachipintegrator/rnachipintegrator_wrapper.xml',
+                      'description': "Integrated analysis of 'gene' and 'peak' data",
+                      'panel_section_id': 'local_toolshed',
+                      'version': '1.0.1.0',
+                      'link': '/galaxy_dev/tool_runner?tool_id=192.168.60.164%2Ftoolshed%2Frepos%2Fpjbriggs%2Frnachipintegrator%2Frnachipintegrator_wrapper%2F1.0.1.0',
+                      'target': 'galaxy_main',
+                      'min_width': -1,
+                      'model_class': 'Tool',
+                      'id': '192.168.60.164/toolshed/repos/pjbriggs/rnachipintegrator/rnachipintegrator_wrapper/1.0.1.0',
+                      'name': 'RnaChipIntegrator'}
         tool = Tool(tool_data)
         self.assertEqual(tool.name,'RnaChipIntegrator')
         self.assertEqual(tool.description,
@@ -90,26 +90,26 @@ class TestTool(unittest.TestCase):
         self.assertEqual(tool.tool_changeset,'2f0a1f1a5725')
 
     def test_load_tool_data_with_tool_shed_repository_data(self):
-        tool_data = { u'panel_section_name': u'NGS: SAMtools',
-                      u'description': u'call variants',
-                      u'name': u'MPileup',
-                      u'labels': [],
-                      u'edam_operations': [],
-                      u'form_style': u'regular',
-                      u'edam_topics': [],
-                      u'panel_section_id': u'samtools',
-                      u'version': u'2.1',
-                      u'link': u'/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fsamtools_mpileup%2Fsamtools_mpileup%2F2.1',
-                      u'min_width': -1,
-                      u'model_class': u'Tool',
-                      u'id': u'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.1',
-                      u'tool_shed_repository':
-                      {u'owner': u'devteam',
-                       u'changeset_revision':
-                       u'820754ab8901',
-                       u'name': u'samtools_mpileup',
-                       u'tool_shed': u'toolshed.g2.bx.psu.edu'},
-                      u'target': u'galaxy_main'}
+        tool_data = { 'panel_section_name': 'NGS: SAMtools',
+                      'description': 'call variants',
+                      'name': 'MPileup',
+                      'labels': [],
+                      'edam_operations': [],
+                      'form_style': 'regular',
+                      'edam_topics': [],
+                      'panel_section_id': 'samtools',
+                      'version': '2.1',
+                      'link': '/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fsamtools_mpileup%2Fsamtools_mpileup%2F2.1',
+                      'min_width': -1,
+                      'model_class': 'Tool',
+                      'id': 'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.1',
+                      'tool_shed_repository':
+                      {'owner': 'devteam',
+                       'changeset_revision':
+                       '820754ab8901',
+                       'name': 'samtools_mpileup',
+                       'tool_shed': 'toolshed.g2.bx.psu.edu'},
+                      'target': 'galaxy_main'}
         tool = Tool(tool_data)
         self.assertEqual(tool.name,'MPileup')
         self.assertEqual(tool.description,"call variants")
@@ -123,17 +123,17 @@ class TestTool(unittest.TestCase):
         self.assertEqual(tool.tool_changeset,'820754ab8901')
 
     def test_load_tool_data_not_from_toolshed(self):
-        tool_data = { u'panel_section_name': u'Get Genomic Scores',
-                      u'config_file': u'/galaxy/tools/filters/wiggle_to_simple.xml',
-                      u'description': u'converter',
-                      u'panel_section_id': u'scores',
-                      u'version': u'1.0.0',
-                      u'link': u'/galaxy_dev/tool_runner?tool_id=wiggle2simple1',
-                      u'target': u'galaxy_main',
-                      u'min_width': -1,
-                      u'model_class': u'Tool',
-                      u'id': u'wiggle2simple1',
-                      u'name': u'Wiggle-to-Interval' }
+        tool_data = { 'panel_section_name': 'Get Genomic Scores',
+                      'config_file': '/galaxy/tools/filters/wiggle_to_simple.xml',
+                      'description': 'converter',
+                      'panel_section_id': 'scores',
+                      'version': '1.0.0',
+                      'link': '/galaxy_dev/tool_runner?tool_id=wiggle2simple1',
+                      'target': 'galaxy_main',
+                      'min_width': -1,
+                      'model_class': 'Tool',
+                      'id': 'wiggle2simple1',
+                      'name': 'Wiggle-to-Interval' }
         tool = Tool(tool_data)
         self.assertEqual(tool.name,'Wiggle-to-Interval')
         self.assertEqual(tool.description,
@@ -148,25 +148,25 @@ class TestRepository(unittest.TestCase):
     """
     """
     def test_load_repo_data(self):
-        repo_data = { u'tool_shed_status':
-                      { u'latest_installable_revision': u'True',
-                        u'revision_update': u'False',
-                        u'revision_upgrade': u'False',
-                        u'repository_deprecated': u'False' },
-                      u'status': u'Installed',
-                      u'name': u'trimmomatic',
-                      u'deleted': False,
-                      u'ctx_rev': u'2',
-                      u'error_message': u'',
-                      u'installed_changeset_revision': u'a60283899c6d',
-                      u'tool_shed': u'toolshed.g2.bx.psu.edu',
-                      u'dist_to_shed': False,
-                      u'url': u'/galaxy_dev/api/tool_shed_repositories/68b273cb7d2d6cff',
-                      u'id': u'68b273cb7d2d6cff',
-                      u'owner': u'pjbriggs',
-                      u'uninstalled': False,
-                      u'changeset_revision': u'a60283899c6d',
-                      u'includes_datatypes': False }
+        repo_data = { 'tool_shed_status':
+                      { 'latest_installable_revision': 'True',
+                        'revision_update': 'False',
+                        'revision_upgrade': 'False',
+                        'repository_deprecated': 'False' },
+                      'status': 'Installed',
+                      'name': 'trimmomatic',
+                      'deleted': False,
+                      'ctx_rev': '2',
+                      'error_message': '',
+                      'installed_changeset_revision': 'a60283899c6d',
+                      'tool_shed': 'toolshed.g2.bx.psu.edu',
+                      'dist_to_shed': False,
+                      'url': '/galaxy_dev/api/tool_shed_repositories/68b273cb7d2d6cff',
+                      'id': '68b273cb7d2d6cff',
+                      'owner': 'pjbriggs',
+                      'uninstalled': False,
+                      'changeset_revision': 'a60283899c6d',
+                      'includes_datatypes': False }
         repo = Repository(repo_data)
         self.assertEqual(repo.name,'trimmomatic')
         self.assertEqual(repo.owner,'pjbriggs')
@@ -188,44 +188,44 @@ class TestRepository(unittest.TestCase):
         self.assertEqual(revisions[0].revision_id,'2:a60283899c6d')
 
     def test_multiple_revisions(self):
-        repo_data1 = { u'tool_shed_status':
-                       { u'latest_installable_revision': u'True',
-                         u'revision_update': u'False',
-                         u'revision_upgrade': u'False',
-                         u'repository_deprecated': u'False' },
-                       u'status': u'Installed',
-                       u'name': u'trimmomatic',
-                       u'deleted': False,
-                       u'ctx_rev': u'2',
-                       u'error_message': u'',
-                       u'installed_changeset_revision': u'a60283899c6d',
-                       u'tool_shed': u'toolshed.g2.bx.psu.edu',
-                       u'dist_to_shed': False,
-                       u'url': u'/galaxy_dev/api/tool_shed_repositories/68b273cb7d2d6cff',
-                       u'id': u'68b273cb7d2d6cff',
-                       u'owner': u'pjbriggs',
-                       u'uninstalled': False,
-                       u'changeset_revision': u'a60283899c6d',
-                       u'includes_datatypes': False }
-        repo_data2 = { u'tool_shed_status':
-                       {u'latest_installable_revision': u'False',
-                        u'revision_update': u'False',
-                        u'revision_upgrade': u'True',
-                        u'repository_deprecated': u'False' },
-                       u'status': u'Installed',
-                       u'name': u'trimmomatic',
-                       u'deleted': False,
-                       u'ctx_rev': u'1',
-                       u'error_message': u'',
-                       u'installed_changeset_revision': u'3358c3d30143',
-                       u'tool_shed': u'toolshed.g2.bx.psu.edu',
-                       u'dist_to_shed': False,
-                       u'url': u'/galaxy_dev/api/tool_shed_repositories/d6f760c242aa425c',
-                       u'id': u'd6f760c242aa425c',
-                       u'owner': u'pjbriggs',
-                       u'uninstalled': False,
-                       u'changeset_revision': u'2bd7cdbb6228',
-                       u'includes_datatypes': False}
+        repo_data1 = { 'tool_shed_status':
+                       { 'latest_installable_revision': 'True',
+                         'revision_update': 'False',
+                         'revision_upgrade': 'False',
+                         'repository_deprecated': 'False' },
+                       'status': 'Installed',
+                       'name': 'trimmomatic',
+                       'deleted': False,
+                       'ctx_rev': '2',
+                       'error_message': '',
+                       'installed_changeset_revision': 'a60283899c6d',
+                       'tool_shed': 'toolshed.g2.bx.psu.edu',
+                       'dist_to_shed': False,
+                       'url': '/galaxy_dev/api/tool_shed_repositories/68b273cb7d2d6cff',
+                       'id': '68b273cb7d2d6cff',
+                       'owner': 'pjbriggs',
+                       'uninstalled': False,
+                       'changeset_revision': 'a60283899c6d',
+                       'includes_datatypes': False }
+        repo_data2 = { 'tool_shed_status':
+                       {'latest_installable_revision': 'False',
+                        'revision_update': 'False',
+                        'revision_upgrade': 'True',
+                        'repository_deprecated': 'False' },
+                       'status': 'Installed',
+                       'name': 'trimmomatic',
+                       'deleted': False,
+                       'ctx_rev': '1',
+                       'error_message': '',
+                       'installed_changeset_revision': '3358c3d30143',
+                       'tool_shed': 'toolshed.g2.bx.psu.edu',
+                       'dist_to_shed': False,
+                       'url': '/galaxy_dev/api/tool_shed_repositories/d6f760c242aa425c',
+                       'id': 'd6f760c242aa425c',
+                       'owner': 'pjbriggs',
+                       'uninstalled': False,
+                       'changeset_revision': '2bd7cdbb6228',
+                       'includes_datatypes': False}
         repo = Repository(repo_data2)
         repo.add_revision(repo_data1)
         self.assertEqual(repo.name,'trimmomatic')
@@ -264,21 +264,21 @@ class TestToolPanelSection(unittest.TestCase):
     """
     """
     def test_load_tool_panel_data_for_toolsection(self):
-        tool_panel_data = { u'model_class': u'ToolSection',
-                            u'version': u'',
-                            u'elems':
-                            [{u'panel_section_name': u'NGS: SAM Tools',
-                              u'description': u'call variants',
-                              u'name': u'MPileup',
-                              u'panel_section_id': u'ngs:_sam_tools',
-                              u'version': u'2.0',
-                              u'link': u'/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fsamtools_mpileup%2Fsamtools_mpileup%2F2.0',
-                              u'min_width': -1,
-                              u'model_class': u'Tool',
-                              u'id': u'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.0',
-                              u'target': u'galaxy_main'}],
-                            u'name': u'NGS: SAM Tools',
-                            u'id': u'ngs:_sam_tools' }
+        tool_panel_data = { 'model_class': 'ToolSection',
+                            'version': '',
+                            'elems':
+                            [{'panel_section_name': 'NGS: SAM Tools',
+                              'description': 'call variants',
+                              'name': 'MPileup',
+                              'panel_section_id': 'ngs:_sam_tools',
+                              'version': '2.0',
+                              'link': '/galaxy_dev/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Fsamtools_mpileup%2Fsamtools_mpileup%2F2.0',
+                              'min_width': -1,
+                              'model_class': 'Tool',
+                              'id': 'toolshed.g2.bx.psu.edu/repos/devteam/samtools_mpileup/samtools_mpileup/2.0',
+                              'target': 'galaxy_main'}],
+                            'name': 'NGS: SAM Tools',
+                            'id': 'ngs:_sam_tools' }
         section = ToolPanelSection(tool_panel_data)
         self.assertEqual(section.name,'NGS: SAM Tools')
         self.assertEqual(section.id,'ngs:_sam_tools')
@@ -296,18 +296,18 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertEqual(len(section.elems[0].elems),0)
 
     def test_load_tool_panel_data_for_tool(self):
-        tool_panel_data = { u'panel_section_name': None,
-                            u'config_file': u'/mnt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/3fdc1a74d866/fastqc/rgFastQC.xml',
-                            u'description': u'Read Quality reports',
-                            u'labels': [],
-                            u'name': u'FastQC',
-                            u'panel_section_id': None,
-                            u'version': u'0.65',
-                            u'link': u'/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Ffastqc%2Ffastqc%2F0.65',
-                            u'min_width': -1,
-                            u'model_class': u'Tool',
-                            u'id': u'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65',
-                            u'target': u'galaxy_main' }
+        tool_panel_data = { 'panel_section_name': None,
+                            'config_file': '/mnt/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/devteam/fastqc/3fdc1a74d866/fastqc/rgFastQC.xml',
+                            'description': 'Read Quality reports',
+                            'labels': [],
+                            'name': 'FastQC',
+                            'panel_section_id': None,
+                            'version': '0.65',
+                            'link': '/tool_runner?tool_id=toolshed.g2.bx.psu.edu%2Frepos%2Fdevteam%2Ffastqc%2Ffastqc%2F0.65',
+                            'min_width': -1,
+                            'model_class': 'Tool',
+                            'id': 'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65',
+                            'target': 'galaxy_main' }
         section = ToolPanelSection(tool_panel_data)
         self.assertEqual(section.name,'FastQC')
         self.assertEqual(section.id,'toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.65')
@@ -318,10 +318,10 @@ class TestToolPanelSection(unittest.TestCase):
         self.assertEqual(len(section.elems),0)
 
     def test_load_tool_panel_data_for_label(self):
-        tool_panel_data = { u'model_class': u'ToolSectionLabel',
-                            u'version': u'',
-                            u'id': u'deprecated',
-                            u'text': u'DEPRECATED' }
+        tool_panel_data = { 'model_class': 'ToolSectionLabel',
+                            'version': '',
+                            'id': 'deprecated',
+                            'text': 'DEPRECATED' }
         section = ToolPanelSection(tool_panel_data)
         self.assertEqual(section.name,None)
         self.assertEqual(section.id,'deprecated')

--- a/test/test_users.py
+++ b/test/test_users.py
@@ -13,25 +13,25 @@ class TestUser(unittest.TestCase):
     """
     def test_load_user_data_minimal(self):
         # Data returned from galaxy.users.UserClient(gi).get_users()
-        user_data = { u'username': u'bloggs',
-                      u'model_class': u'User',
-                      u'id': u'd6fbfd317568bb93',
-                      u'email': u'joe.bloggs@galaxy.org' }
+        user_data = { 'username': 'bloggs',
+                      'model_class': 'User',
+                      'id': 'd6fbfd317568bb93',
+                      'email': 'joe.bloggs@galaxy.org' }
         user = User(user_data)
         self.assertEqual(user.username,'bloggs')
         self.assertEqual(user.email,'joe.bloggs@galaxy.org')
         self.assertEqual(user.id,'d6fbfd317568bb93')
     def test_load_user_data_full(self):
         # Data returned from galaxy.users.UserClient(gi).show_user()
-        user_data = { u'username': u'bloggs',
-                      u'quota_percent': 4,
-                      u'total_disk_usage': 13181590307.0,
-                      u'nice_total_disk_usage': u'12.3 GB',
-                      u'id': u'd6fbfd317568bb93',
-                      u'is_admin': True,
-                      u'tags_used': [],
-                      u'model_class': u'User',
-                      u'email': u'joe.bloggs@galaxy.org' }
+        user_data = { 'username': 'bloggs',
+                      'quota_percent': 4,
+                      'total_disk_usage': 13181590307.0,
+                      'nice_total_disk_usage': '12.3 GB',
+                      'id': 'd6fbfd317568bb93',
+                      'is_admin': True,
+                      'tags_used': [],
+                      'model_class': 'User',
+                      'email': 'joe.bloggs@galaxy.org' }
         user = User(user_data)
         self.assertEqual(user.username,'bloggs')
         self.assertEqual(user.email,'joe.bloggs@galaxy.org')


### PR DESCRIPTION
Fixes https://github.com/pjbriggs/nebulizer/issues/87.

Adds `python_requires=">=3.6"`, so pip will only install this version of the library for users with Python 3.6+. Those with older versions will get an earlier version.

Upgrade Python syntax with https://github.com/asottile/pyupgrade using `--py36-plus`

Also test on Python 3.9 beta, due out in October.

Finally, update a few URLs.