### PR TITLE
WIP implement 'disk_usage' command to estimate space consumed by user data

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -16,6 +16,7 @@ from .core import prompt_for_confirmation
 from .core import turn_off_urllib3_warnings
 from .core import Credentials
 from .core import Reporter
+from .utils import bytes_to_size
 from . import options
 from . import users
 from . import libraries
@@ -1165,6 +1166,44 @@ def config(context,galaxy,name=None):
     for item in items:
         output.append((item,config[item]))
     output.report(rstrip=True)
+
+@nebulizer.command()
+@click.argument("galaxy")
+@pass_context
+def disk_usage(context,galaxy):
+    """
+    Summarise user disk usage for GALAXY
+
+    Estimates the disk space used by all users
+    by summing up their disk usage according to
+    GALAXY. Note that this might not be accurate.
+
+    If GALAXY has quotas enabled then also gives
+    an estimate of the committed disk space (i.e.
+    space that would be used if all users filled
+    up their allocation).
+    """
+    # Get a Galaxy instance
+    gi = context.galaxy_instance(galaxy)
+    if gi is None:
+        logger.critical("Failed to connect to Galaxy instance")
+        sys.exit(1)
+    # Check if quotas are enabled
+    quotas_enabled = get_galaxy_config(gi)['enable_quotas']
+    # Get disk usage summed over all users
+    try:
+        usage,commitment = users.get_disk_usage(gi)
+        click.echo("Total usage: %s (%d)" % (bytes_to_size(usage),
+                                             usage))
+        if quotas_enabled:
+            click.echo("Commitment : %s (%d)" % (bytes_to_size(commitment),
+                                                 commitment))
+        else:
+            click.echo("Commitment : N/A (quotas not enabled)")
+    except ConnectionError as ex:
+        logger.fatal("Failed to get user list: %s (%s)" % (ex.body,
+                                                           ex.status_code))
+        return 1
 
 @nebulizer.command()
 @click.option('-c','--count',metavar='COUNT',default=0,

--- a/nebulizer/utils.py
+++ b/nebulizer/utils.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# utils: utility classes and functions for nebulizer
+
+def size_to_bytes(size):
+    """
+    Convert human-readable size to bytes
+
+    Arguments:
+      size (str): human-readable size (e.g.
+        '1KB','1.5GB')
+
+    Returns:
+      Integer: size converted to bytes
+    """
+    size = str(size).upper()
+    units = ('K','M','G','T','P')
+    for m,unit in enumerate(units):
+        m_ = 1024**(m + 1)
+        if size.endswith(unit):
+            return int(float(size[:-1].strip())*m_)
+        elif size.endswith("%sB" % unit):
+            return int(float(size[:-2].strip())*m_)
+    # No match to units, assume bytes
+    return int(size)
+
+def bytes_to_size(bytes_):
+    """
+    Convert bytes to human-readable size
+
+    Arguments:
+      bytes_ (int): number of bytes
+
+    Returns:
+      String: bytes converted to human-readable
+        format (e.g. '1 KB','1.5 GB')
+    """
+    units = ('','KB','MB','GB','TB','PB')
+    size = float(bytes_)
+    i = 0
+    while size >= 1024:
+        size = size/1024.0
+        i += 1
+    if not units[i]:
+        return "%d" % size
+    else:
+        size = "%.2f" % size
+        if size.endswith('0'):
+            size = size[:-1]
+        if size.endswith('.'):
+            size += '0'
+    return "%s %s" % (size,units[i])

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import unittest
+import tempfile
+import shutil
+import os
+from nebulizer.utils import size_to_bytes
+from nebulizer.utils import bytes_to_size
+
+class TestSizeToBytes(unittest.TestCase):
+    def test_size_to_bytes(self):
+        """
+        size_to_bytes: check conversions from human-readable to bytes
+        """
+        # Bytes to bytes
+        self.assertEqual(size_to_bytes('100'),100)
+        # KB to bytes
+        self.assertEqual(size_to_bytes('1KB'),1024)
+        self.assertEqual(size_to_bytes('1K'),1024)
+        self.assertEqual(size_to_bytes('1kb'),1024)
+        self.assertEqual(size_to_bytes('1.0 KB'),1024)
+        # MB to bytes
+        self.assertEqual(size_to_bytes('1.5MB'),1572864)
+        self.assertEqual(size_to_bytes('1.5M'),1572864)
+        self.assertEqual(size_to_bytes('1.5mb'),1572864)
+        self.assertEqual(size_to_bytes('1.5 MB'),1572864)
+        # GB to bytes
+        self.assertEqual(size_to_bytes('2.75GB'),2952790016)
+        self.assertEqual(size_to_bytes('2.75G'),2952790016)
+        self.assertEqual(size_to_bytes('2.75gb'),2952790016)
+        self.assertEqual(size_to_bytes('2.75 GB'),2952790016)
+        # TB to bytes
+        self.assertEqual(size_to_bytes('1.1TB'),
+                         int(1.1*1024.0*1024.0*1024.0*1024.0))
+        self.assertEqual(size_to_bytes('1.1T'),
+                         int(1.1*1024.0*1024.0*1024.0*1024.0))
+        self.assertEqual(size_to_bytes('1.1tb'),
+                         int(1.1*1024.0*1024.0*1024.0*1024.0))
+        self.assertEqual(size_to_bytes('1.1 TB'),
+                         int(1.1*1024.0*1024.0*1024.0*1024.0))
+
+class TestBytesToSize(unittest.TestCase):
+    def test_bytes_to_size(self):
+        """
+        bytes_to_size: check conversions from bytes to human-readable
+        """
+        # Bytes to bytes
+        self.assertEqual(bytes_to_size(100),'100')
+        # Bytes to KB
+        self.assertEqual(bytes_to_size(1024),'1.0 KB')
+        # Bytes to MB
+        self.assertEqual(bytes_to_size(1572864),'1.5 MB')
+        # Bytes to GB
+        self.assertEqual(bytes_to_size(2952790016),'2.75 GB')
+        # Bytes to TB
+        self.assertEqual(bytes_to_size(int(1.1*1024.0*1024.0*1024.0*1024.0)),
+                         '1.1 TB')


### PR DESCRIPTION
PR which attempts to address issue #96 by implementing functionality for a `disk_usage` command: this estimates the disk space consumed on a Galaxy server by user data, by adding up the disk usage for all users, so it may not be accurate if the disk usage according to Galaxy isn't correct.

If the Galaxy server has quotas enabled then this command also estimates the amount of space that is committed, by totalling up the quotas for each user.

There are some issues:

* If any users have 'unlimited' quotas then the committed disk space is effectively infinite
* It's not clear how to handle deleted users when calculating the commited space