### PR TITLE
list_users: enable sorting by disk usage, quota etc

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -19,6 +19,10 @@ instance:
   ``active`` (the default), ``deleted`` (only list deleted
   users which haven't been purged) or ``all`` (list all active,
   deleted, and purged users).
+* ``--sort``: specify one or more fields to sort the output on;
+  valid fields are ``email``, ``disk_usage``, ``quota``,
+  ``quota_usage``. Multiple fields should be separated by commas
+  (e.g. ``--sort=quota,disk_usage``).
 * ``--name``: filter list on user email (can include glob-style
   wildcards e.g. ``--name="*bloggs*"``).
 

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -320,8 +320,8 @@ def remove_key(context,alias):
 @click.option("--sort",
               default='email',
               help="comma-separated list of fields to output on; "
-              "valid fields are 'email', 'disk_usage' (default: "
-              "'email').")
+              "valid fields are 'email', 'disk_usage', 'quota', "
+              "'quota_usage' (default: 'email').")
 @click.option("--show_id",is_flag=True,
               help="include internal Galaxy user ID.")
 @click.argument("galaxy")
@@ -340,7 +340,7 @@ def list_users(context,galaxy,name,status,long_listing,sort,show_id):
     # Turn sort keys into a list
     sort_keys = sort.split(',')
     for key in sort_keys:
-        if key not in ('email','disk_usage'):
+        if key not in ('email','disk_usage','quota','quota_usage'):
             logger.fatal("'%s': invalid sort key" % key)
             sys.exit(1)
     # List users

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -318,10 +318,10 @@ def remove_key(context,alias):
               help="use a long listing format that includes ids,"
               " disk usage and admin status.")
 @click.option("--sort",
-              type=click.Choice(['email','disk_usage',]),
               default='email',
-              help="property to sort output on; can be one of "
-              "'email', 'disk_usage' (default: 'email').")
+              help="comma-separated list of fields to output on; "
+              "valid fields are 'email', 'disk_usage' (default: "
+              "'email').")
 @click.option("--show_id",is_flag=True,
               help="include internal Galaxy user ID.")
 @click.argument("galaxy")
@@ -337,10 +337,16 @@ def list_users(context,galaxy,name,status,long_listing,sort,show_id):
     if gi is None:
         logger.critical("Failed to connect to Galaxy instance")
         sys.exit(1)
+    # Turn sort keys into a list
+    sort_keys = sort.split(',')
+    for key in sort_keys:
+        if key not in ('email','disk_usage'):
+            logger.fatal("'%s': invalid sort key" % key)
+            sys.exit(1)
     # List users
     sys.exit(users.list_users(gi,name=name,
                               long_listing_format=long_listing,
-                              sort_by=sort,
+                              sort_by=sort_keys,
                               status=status,
                               show_id=show_id))
 

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -311,16 +311,22 @@ def remove_key(context,alias):
 @click.option("--status",
               type=click.Choice(['active','deleted','purged','all']),
               default='active',
-              help="list users with the specified status (default: "
-              "'active')")
+              help="list users with the specified status; can be "
+              "one of 'active', 'deleted', 'purged', 'all' "
+              "(default: 'active')")
 @click.option("--long","-l","long_listing",is_flag=True,
               help="use a long listing format that includes ids,"
               " disk usage and admin status.")
+@click.option("--sort",
+              type=click.Choice(['email','disk_usage',]),
+              default='email',
+              help="property to sort output on; can be one of "
+              "'email', 'disk_usage' (default: 'email').")
 @click.option("--show_id",is_flag=True,
               help="include internal Galaxy user ID.")
 @click.argument("galaxy")
 @pass_context
-def list_users(context,galaxy,name,status,long_listing,show_id):
+def list_users(context,galaxy,name,status,long_listing,sort,show_id):
     """
     List users in Galaxy instance.
 
@@ -334,6 +340,7 @@ def list_users(context,galaxy,name,status,long_listing,show_id):
     # List users
     sys.exit(users.list_users(gi,name=name,
                               long_listing_format=long_listing,
+                              sort_by=sort,
                               status=status,
                               show_id=show_id))
 

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -204,7 +204,7 @@ def get_user_id(gi,email):
         return None
 
 def list_users(gi,name=None,long_listing_format=False,status='active',
-               sort_by='email',show_id=False):
+               sort_by=None,show_id=False):
     """
     List users in Galaxy instance
 
@@ -216,8 +216,8 @@ def list_users(gi,name=None,long_listing_format=False,status='active',
       status (str): list users with matching status: 'active'
         (default), 'deleted', or 'purged'. Use 'all' to list
         all accounts regardless of status
-      sort_by (str): sort users into order on this field:
-        'email' (default), 'disk_usage'
+      sort_by (list): list of fields to sort users into order
+        on this field (default sorting is done on user email)
       show_id (bool): if True then report user's Galaxy ID
 
     """
@@ -242,7 +242,9 @@ def list_users(gi,name=None,long_listing_format=False,status='active',
                  (fnmatch.fnmatch(u.username.lower(),name) or
                   fnmatch.fnmatch(u.email.lower(),name))]
     # Sort into order
-    users.sort(key=lambda u: u.sort_key(sort_by))
+    if not sort_by:
+        sort_by = ()
+    users.sort(key=lambda u: u.sort_key(*sort_by))
     # Report users
     output = Reporter()
     for user in users:

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -149,8 +149,8 @@ def get_user_id(gi,email):
     except AttributeError:
         return None
 
-def list_users(gi,name=None,long_listing_format=False,status=False,
-               show_id=False):
+def list_users(gi,name=None,long_listing_format=False,status='active',
+               sort_by='email',show_id=False):
     """
     List users in Galaxy instance
 
@@ -162,6 +162,8 @@ def list_users(gi,name=None,long_listing_format=False,status=False,
       status (str): list users with matching status: 'active'
         (default), 'deleted', or 'purged'. Use 'all' to list
         all accounts regardless of status
+      sort_by (str): sort users into order on this field:
+        'email' (default), 'disk_usage'
       show_id (bool): if True then report user's Galaxy ID
 
     """
@@ -185,9 +187,14 @@ def list_users(gi,name=None,long_listing_format=False,status=False,
         users = [u for u in users if
                  (fnmatch.fnmatch(u.username.lower(),name) or
                   fnmatch.fnmatch(u.email.lower(),name))]
+    # Sort into order
+    if sort_by == 'email':
+        sort_func = lambda u: u.email.lower() \
+                    if not (u.purged and '@' not in u.email) else ''
+    elif sort_by == 'disk_usage':
+        sort_func = lambda u: -u.total_disk_usage
+    users.sort(key=sort_func)
     # Report users
-    users.sort(key=lambda u: u.email.lower()
-               if not (u.purged and '@' not in u.email) else '')
     output = Reporter()
     for user in users:
         # Collect data items to report

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -76,6 +76,29 @@ class User(object):
             except AttributeError:
                 pass
 
+    @property
+    def display_status(self):
+        """
+        Return status based on the user data
+
+        Status will be returned as one of:
+
+        - active
+        - deleted
+        - purged
+
+        or an empty string, depending on the `purged`,
+        `deleted` and `active` flag.
+        """
+        if self.purged:
+            return 'purged'
+        elif self.deleted:
+            return 'deleted'
+        elif self.active:
+            return 'active'
+        else:
+            return ''
+
 # Functions
 
 def get_users(gi,status='active'):
@@ -207,7 +230,7 @@ def list_users(gi,name=None,long_listing_format=False,status='active',
             # - disk usage
             # - quota size (if quotas enabled)
             # - % quota used (if quotas enabled)
-            # - if account is active
+            # - if account status ('active','deleted' etc)
             # - if user is an admin
             display_items.append(user.nice_total_disk_usage)
             if enable_quotas:
@@ -215,16 +238,8 @@ def list_users(gi,name=None,long_listing_format=False,status='active',
                                       "%s%%" % user.quota_percent
                                       if user.quota_percent
                                       else "0%"])
-            if user.purged:
-                status = 'purged'
-            elif user.deleted:
-                status = 'deleted'
-            elif user.active:
-                status = 'active'
-            else:
-                status = ''
-            display_items.append(status)
-            display_items.append('admin' if user.is_admin else '')
+            display_items.extend([user.display_status,
+                                  'admin' if user.is_admin else ''])
         if show_id:
             # Also report the internal user ID
             display_items.append(user.id)

--- a/nebulizer/users.py
+++ b/nebulizer/users.py
@@ -99,6 +99,22 @@ class User(object):
         else:
             return ''
 
+    @property
+    def display_quota_percent(self):
+        """
+        Return quota percentage for display
+
+        Percentage will be 'n/a' for unlimited
+        quotas, or a value with a percentage
+        symbol for real quotas.
+        """
+        if self.quota == 'unlimited':
+            return 'n/a'
+        elif self.quota_percent:
+            return "%s%%" % self.quota_percent
+        else:
+            return "0%"
+
     def sort_key(self,*keys):
         """
         Return 'sort key' based on specified keys
@@ -304,14 +320,8 @@ def list_users(gi,name=None,long_listing_format=False,status='active',
             # - if user is an admin
             display_items.append(user.nice_total_disk_usage)
             if enable_quotas:
-                if user.quota == 'unlimited':
-                    quota_percent = 'n/a'
-                elif user.quota_percent:
-                    quota_percent = "%s%%" % user.quota_percent
-                else:
-                    quota_percent = "0%"
                 display_items.extend([user.quota,
-                                      quota_percent])
+                                      user.display_quota_percent])
             display_items.extend([user.display_status,
                                   'admin' if user.is_admin else ''])
         if show_id:

--- a/test/test_users.py
+++ b/test/test_users.py
@@ -21,6 +21,7 @@ class TestUser(unittest.TestCase):
         self.assertEqual(user.username,'bloggs')
         self.assertEqual(user.email,'joe.bloggs@galaxy.org')
         self.assertEqual(user.id,'d6fbfd317568bb93')
+        self.assertEqual(user.display_status,'')
     def test_load_user_data_full(self):
         # Data returned from galaxy.users.UserClient(gi).show_user()
         user_data = { u'username': u'bloggs',
@@ -31,7 +32,10 @@ class TestUser(unittest.TestCase):
                       u'is_admin': True,
                       u'tags_used': [],
                       u'model_class': u'User',
-                      u'email': u'joe.bloggs@galaxy.org' }
+                      u'email': u'joe.bloggs@galaxy.org',
+                      u'active': True,
+                      u'deleted': False,
+                      u'purged': False, }
         user = User(user_data)
         self.assertEqual(user.username,'bloggs')
         self.assertEqual(user.email,'joe.bloggs@galaxy.org')
@@ -40,6 +44,7 @@ class TestUser(unittest.TestCase):
         self.assertEqual(user.total_disk_usage,13181590307.0)
         self.assertTrue(user.is_admin)
         self.assertEqual(user.nice_total_disk_usage,'12.3 GB')
+        self.assertEqual(user.display_status,'active')
 
 class TestCheckUsernameFormat(unittest.TestCase):
     def test_valid_username(self):


### PR DESCRIPTION
PR which adds a new `--sort` option to the `list_users` command, to allow sorting of users by disk usage rather than the default (email) by specifying `--sort disk_usage`.

Additional sorting options are `quota` and `quota_usage`; multiple fields can be specified by separating with a comma (e.g. `--sort quota,disk_usage`).

PR also makes some updates to the internals for displaying 'nice' versions of the percentage quotas and user status.

This PR aims to address issue #85.