### PR TITLE
Test on and declare support for Python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9-dev"
+  - "3.9"
 
 install:
   - "pip install ."

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         "Programming Language :: Python :: 3 :: Only",
     ],
     include_package_data=True,


### PR DESCRIPTION
Python 3.9 was released in October.

We can now test on stable 3.9 and declare support for it in the classifiers.