### PR TITLE
Rename 'quota' commands

### DIFF
--- a/docs/quotas.rst
+++ b/docs/quotas.rst
@@ -22,11 +22,11 @@ Querying quotas
 Creating and deleting quotas
 ----------------------------
 
-``quotaadd`` defines a new quota:
+``quota_add`` defines a new quota:
 
 ::
 
-   nebulizer quotaadd GALAXY QUOTA_NAME SIZE
+   nebulizer quota_add GALAXY QUOTA_NAME SIZE
 
 ``SIZE`` can either be an amount (e.g. ``10GB``, ``0.2 T``) or
 an amount preceeded by an operation (one of ``+``, ``-`` or
@@ -46,25 +46,25 @@ Users and groups can be associated with the new quota using the
 * ``-g``/``--groups``: associate one or more groups with the
   quota, as a comma-separated list of group names.
 
-``quotadel`` deletes an existing quota:
+``quota_del`` deletes an existing quota:
 
 ::
 
-   nebulizer quotadel GALAXY QUOTA_NAME
+   nebulizer quota_del GALAXY QUOTA_NAME
 
 .. note::
 
    A deleted quota can be restored using the ``--undelete``
-   option of the ``quotamod`` command.
+   option of the ``quota_mod`` command.
 
 Modifying quota definitions
 ---------------------------
 
-``quotamod`` updates a quota definition:
+``quota_mod`` updates a quota definition:
 
 ::
 
-   nebulizer quotamod GALAXY QUOTA_NAME ...
+   nebulizer quota_mod GALAXY QUOTA_NAME ...
 
 Options allow various quota properties to be modified:
 

--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -1184,7 +1184,7 @@ def quotas(context,galaxy,name,status,long_listing):
                          status=status,
                          long_listing_format=long_listing))
 
-@nebulizer.command(name="quotaadd")
+@nebulizer.command(name="quota_add")
 @click.option('-d','--description',
               help="description of the new quota (will be "
               "the same as the NAME if not supplied).")
@@ -1201,8 +1201,8 @@ def quotas(context,galaxy,name,status,long_listing):
 @click.argument("name")
 @click.argument("quota")
 @pass_context
-def quotaadd(context,galaxy,name,quota,description=None,
-             default_for=None,users=None,groups=None):
+def quota_add(context,galaxy,name,quota,description=None,
+              default_for=None,users=None,groups=None):
     """
     Create new quota.
 
@@ -1252,7 +1252,7 @@ def quotaadd(context,galaxy,name,quota,description=None,
                           users=users,
                           groups=groups))
 
-@nebulizer.command(name="quotamod")
+@nebulizer.command(name="quota_mod")
 @click.option('-n','--name',metavar="NEW_NAME",
               help="new name for the quota.")
 @click.option('-d','--description',metavar="NEW_DESCRIPTION",
@@ -1280,10 +1280,10 @@ def quotaadd(context,galaxy,name,quota,description=None,
 @click.argument("galaxy")
 @click.argument("quota")
 @pass_context
-def quotamod(context,galaxy,quota,name=None,description=None,
-             quota_size=None,default_for=None,add_users=None,
-             remove_users=None,add_groups=None,remove_groups=None,
-             undelete=False):
+def quota_mod(context,galaxy,quota,name=None,description=None,
+              quota_size=None,default_for=None,add_users=None,
+              remove_users=None,add_groups=None,remove_groups=None,
+              undelete=False):
     """
     Modify an existing quota.
 
@@ -1330,13 +1330,13 @@ def quotamod(context,galaxy,quota,name=None,description=None,
                           remove_groups=remove_groups,
                           undelete=undelete))
 
-@nebulizer.command(name="quotadel")
+@nebulizer.command(name="quota_del")
 @click.argument("galaxy")
 @click.argument("quota")
 @click.option('-y','--yes',is_flag=True,
               help="don't ask for confirmation of deletions.")
 @pass_context
-def quotadel(context,galaxy,quota,yes):
+def quota_del(context,galaxy,quota,yes):
     """
     Delete quota.
 


### PR DESCRIPTION
PR which renames the `quota...` commands for improved readability:

* `quotaadd` -> `quota_add`
* `quotadel` -> `quota_del`
* `quotamod` -> `quota_mod`