### PR TITLE
Update 'install_tool' command to prompt for confirmation

### DIFF
--- a/nebulizer/cli.py
+++ b/nebulizer/cli.py
@@ -649,6 +649,8 @@ def list_tool_panel(context,galaxy,name,list_tools):
 @click.option('--no-wait',is_flag=True,
               help="don't wait for lengthy tool installations to "
               "complete.")
+@click.option('-y','--yes',is_flag=True,
+              help="don't ask for confirmation of installation.")
 @click.argument("galaxy")
 @click.argument("repository",nargs=-1)
 @pass_context
@@ -656,7 +658,7 @@ def install_tool(context,galaxy,repository,tool_panel_section,
                  install_tool_dependencies,
                  install_repository_dependencies,
                  install_resolver_dependencies,
-                 timeout,no_wait):
+                 timeout,no_wait,yes):
     """
     Install tool from toolshed.
 
@@ -704,7 +706,8 @@ def install_tool(context,galaxy,repository,tool_panel_section,
         install_repository_dependencies=
         (install_repository_dependencies== 'yes'),
         install_resolver_dependencies=
-        (install_resolver_dependencies== 'yes')))
+        (install_resolver_dependencies== 'yes'),
+        no_confirm=yes))
 
 @nebulizer.command(name="list_repositories")
 @click.option('--name',metavar='NAME',

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1196,6 +1196,7 @@ def update_tool(gi,tool_shed,name,owner,
     # Loop over matching repositories and check for
     # installed revisions
     update_repos = []
+    no_update_repos = []
     for repo in repos:
         # Check there is at least one installed revision
         installed_revisions = [r for r in repo.revisions()
@@ -1224,10 +1225,23 @@ def update_tool(gi,tool_shed,name,owner,
         # Repository can be updated
         if update_available:
             update_repos.append(repo)
+        else:
+            no_update_repos.append(repo)
+    # Report matching repos with no updates to install
+    if no_update_repos:
+        print("The following tool repositories are up to date:\n")
+        for r in no_update_repos:
+            print("\t%s %s/%s" % (r.tool_shed,r.owner,r.name))
+        print("")
     # Check if there are any tools to update
     if not update_repos:
-        logger.fatal("%s/%s: no repositories to update" % (owner,name))
-        return TOOL_UPDATE_FAIL
+        if no_update_repos:
+            print("All tools up to date: nothing to do")
+            return TOOL_UPDATE_OK
+        else:
+            logger.fatal("%s/%s: no repositories to update" %
+                         (owner,name))
+            return TOOL_UPDATE_FAIL
     # Report what will be updated and confirm
     print("The following tool repositories will be updated:\n")
     for r in update_repos:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1524,5 +1524,5 @@ def _install_tool(gi,tool_shed,owner,name,revision,
             logger.critical(f"{owner}/{name}: failed ({install_status})")
             return TOOL_INSTALL_FAIL
     # Reaching here means timed out
-    logger.critical("%/%s: timed out waiting for install" % (owner,name))
+    logger.critical("%s/%s: timed out waiting for install" % (owner,name))
     return TOOL_INSTALL_TIMEOUT

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1253,17 +1253,14 @@ def update_tool(gi,tool_shed,name,owner,
             if tool.tool_repo == update_repo.id:
                 tool_panel_section = tool.panel_section
                 break
-        if tool_panel_section is None:
-            logger.warning("%s/%s: no tool panel section found" %
-                           (update_repo.owner,update_repo.name))
-        #print("Installing update under %s" % tool_panel_section)
-        status = install_tool(
-            gi,update_repo.tool_shed,update_repo.name,
-            update_repo.owner,revision,
+        # Install the update
+        status = _install_tool(
+            gi,update_repo.tool_shed,update_repo.owner,
+            update_repo.name,revision,
+            tool_panel_section=tool_panel_section,
             install_tool_dependencies=install_tool_dependencies,
             install_repository_dependencies=install_repository_dependencies,
             install_resolver_dependencies=install_resolver_dependencies,
-            tool_panel_section=tool_panel_section,
             timeout=timeout,poll_interval=poll_interval,
             no_wait=no_wait)
         if status != TOOL_INSTALL_OK:

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1179,8 +1179,8 @@ def update_tool(gi,tool_shed,name,owner,
         revisions against the tool shed, to determine if
         updates are available for the tool (default is
         False i.e. do not check status against toolshed)
-      no_confirm : if True then don't prompt to confirm the
-        uninstall operation.
+      no_confirm (boolean): if True then don't prompt to
+        confirm the update operation.
     """
     # Locate the existing installation
     repos = []

--- a/nebulizer/tools.py
+++ b/nebulizer/tools.py
@@ -1255,10 +1255,10 @@ def update_tool(gi,tool_shed,name,owner,
     update_status = TOOL_UPDATE_OK
     for ix,update_repo in enumerate(update_repos):
         if len(update_repos) > 1:
-            print("[%d/%d]: updating %s/%s" % (ix+1,
-                                               len(update_repos),
-                                               update_repo.owner,
-                                               update_repo.name))
+            print("\n[%d/%d]: updating %s/%s" % (ix+1,
+                                                 len(update_repos),
+                                                 update_repo.owner,
+                                                 update_repo.name))
         #  Get latest revision
         revision = update_repo.tool_shed_revisions()[-1]
         # Locate tool panel section for existing tools


### PR DESCRIPTION
PR to address issue #105 by updating the `install_tool` command to prompt the user for confirmation by default before completing the tool installation; a new `-y` command line option overrides the prompting.

Additionally, internally the core code for handling tool installation is also moved to a new function so it can be accessed from both `install_tool` and `update_tool`.

Together these changes should make the behaviour of the tool installation and update commands more consistent from the user perspective.