### PR TITLE
Update nebulizer dependencies to bioblend 0.16.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bioblend==0.15.0
+bioblend==0.16.0
 mako
 click==7.1.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import codecs
 import os.path
 
 # Installation requirements
-install_requires = ['bioblend==0.15.0',
+install_requires = ['bioblend==0.16.0',
                     'mako',
                     'click==7.1.2',]
 


### PR DESCRIPTION
PR to address issue #121 by updating `nebulizer` to work with `bioblend` version 0.16.0.